### PR TITLE
Change RMS value table to show generic roughness parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
   "Select" page (#618)
 - added "Download" button for downloading all surfaces
   related to the current selection (#642)
-- fixed bug that no average curve was shown if a surface
-  was selected by tag only (#632)
 - make two different averages distinguishable in plot
   widgets if one is published by adding version number
   to label
-- now longer use "e" notation on plot axis, but scientific
+- added columns "from" and "symbol" to RMS values,
+  added more values, show number as decimal powers (#651)  
+- no longer use "e" notation on plot axis, but scientific
   notation with power of 10 (#636)  
 - moved labels of colorbars next to colorbars (#592)
 - in analyses results for height/slope/curvature distribution,
@@ -22,6 +22,9 @@
 - upgrade to SurfaceTopography 0.93.0 (#643)  
 - upgrade to Django 2.2.20 because of CVE
 - upgrade of packages py and django-debug-toolbar because of CVEs
+- fixed bug that no average curve was shown if a surface
+  was selected by tag only (#632)
+
 
 ## 0.10.1 (2021-03-31)
 

--- a/topobank/analysis/downloads.py
+++ b/topobank/analysis/downloads.py
@@ -406,11 +406,13 @@ def download_rms_table_analyses_to_txt(request, analyses):
                          topography.name,
                          row['quantity'],
                          row['direction'] if row['direction'] else '',
-                         row['value'],
+                         row['area_value'],
+                         row['profile_value'],
                          row['unit']])
 
     f.write('# Table of RMS Values\n')
-    df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction', 'value', 'unit'])
+    df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction',
+                                     'value_S_q', 'value_R_q', 'unit'])
     df.to_csv(f, index=False)
     f.write('\n')
 
@@ -454,7 +456,9 @@ def download_rms_table_analyses_to_xlsx(request, analyses):
             row['measurement'] = topo.name
             data.append(row)
 
-    rms_df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction', 'value', 'unit'])
+    rms_df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction',
+                                         'area_value', 'profile_value', 'unit'])
+    rms_df.rename(columns={'area_value': 'Value S_q', 'profile_value': 'Value R_q'}, inplace=True)
     rms_df.to_excel(excel, sheet_name="RMS values", index=False)
     info_df = _analyses_meta_data_dataframe(analyses, request)
     info_df.to_excel(excel, sheet_name='INFORMATION', index=False)

--- a/topobank/analysis/downloads.py
+++ b/topobank/analysis/downloads.py
@@ -406,13 +406,14 @@ def download_rms_table_analyses_to_txt(request, analyses):
                          topography.name,
                          row['quantity'],
                          row['direction'] if row['direction'] else '',
-                         row['area_value'],
-                         row['profile_value'],
+                         row['from'] if row['from'] else '',
+                         row['symbol'] if row['symbol'] else '',
+                         row['value'],
                          row['unit']])
 
     f.write('# Table of RMS Values\n')
     df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction',
-                                     'value_S_q', 'value_R_q', 'unit'])
+                                     'from', 'symbol', 'value', 'unit'])
     df.to_csv(f, index=False)
     f.write('\n')
 
@@ -457,8 +458,7 @@ def download_rms_table_analyses_to_xlsx(request, analyses):
             data.append(row)
 
     rms_df = pd.DataFrame(data, columns=['surface', 'measurement', 'quantity', 'direction',
-                                         'area_value', 'profile_value', 'unit'])
-    rms_df.rename(columns={'area_value': 'Value S_q', 'profile_value': 'Value R_q'}, inplace=True)
+                                         'from', 'symbol', 'value', 'unit'])
     rms_df.to_excel(excel, sheet_name="RMS values", index=False)
     info_df = _analyses_meta_data_dataframe(analyses, request)
     info_df.to_excel(excel, sheet_name='INFORMATION', index=False)

--- a/topobank/analysis/functions.py
+++ b/topobank/analysis/functions.py
@@ -1222,35 +1222,34 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
     #
     # RMS gradient/slope
     #
+    result.extend([
+        {
+            'quantity': 'RMS slope',
+            'from': FROM_1D,
+            'symbol': 'R&Delta;q',
+            'direction': 'x',
+            'value': topography.rms_slope_from_profile(),  # x direction
+            'unit': 1,
+        }
+    ])
     if is_2D:
         result.extend([
             {
-                'quantity': 'RMS gradient',
-                'from': '',
-                'symbol': 'R&Delta;q',  # HTML
-                'direction': 'x',
-                'value': topography.rms_gradient(),  # x direction
-                'unit': 1,
-            },
-            {
-                'quantity': 'RMS gradient',
-                'from': '',
-                'symbol': 'R&Delta;q',
-                'direction': 'y',
-                'value': topography.transpose().rms_gradient(),  # y direction
-                'unit': 1,
-            },
-        ])
-    elif topography.dim == 1:
-        result.extend([
-            {
-                'quantity': 'RMS slope',  # TODO slope or gradient?
+                'quantity': 'RMS slope',
                 'from': FROM_1D,
-                'symbol': 'R&Delta;q',
-                'direction': 'x',
-                'value': topography.rms_slope_from_profile(),
+                'symbol': 'R&Delta;q',  # HTML
+                'direction': 'y',
+                'value': topography.transpose().rms_slope_from_profile(),  # y direction
                 'unit': 1,
-            }
+            },
+            {
+                'quantity': 'RMS gradient',
+                'from': FROM_2D,
+                'symbol': '',
+                'direction': '',
+                'value': topography.rms_gradient(),
+                'unit': 1,
+            },
         ])
 
     return result

--- a/topobank/analysis/functions.py
+++ b/topobank/analysis/functions.py
@@ -1154,15 +1154,19 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
         {
             'quantity': 'RMS Height',
             'direction': None,
-            'value': topography.rms_height_from_area() if topography.dim == 2
-            else topography.rms_height_from_profile(),
+            'area_value': topography.rms_height_from_area()
+            if hasattr(topography, 'rms_height_from_area') else None,
+            'profile_value': topography.rms_height_from_profile()
+            if hasattr(topography, 'rms_height_from_profile') else None,
             'unit': unit,
         },
         {
             'quantity': 'RMS Curvature',
             'direction': None,
-            'value': topography.rms_curvature_from_area() if topography.dim == 2
-            else topography.rms_curvature_from_profile(),
+            'area_value': topography.rms_curvature_from_area()
+            if hasattr(topography, 'rms_curvature_from_area') else None,
+            'profile_value': topography.rms_curvature_from_profile()
+            if hasattr(topography, 'rms_curvature_from_profile') else None,
             'unit': inverse_unit,
         },
     ]
@@ -1173,13 +1177,15 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
             {
                 'quantity': 'RMS Slope',
                 'direction': 'x',
-                'value': rms_slope_from_der(dh_dx),
+                'area_value': None,
+                'profile_value': rms_slope_from_der(dh_dx),  # TODO Correct?
                 'unit': 1,
             },
             {
                 'quantity': 'RMS Slope',
                 'direction': 'y',
-                'value': rms_slope_from_der(dh_dy),
+                'area_value': None,
+                'profile_value': rms_slope_from_der(dh_dy),  # TODO Correct?
                 'unit': 1,
             }
         ])
@@ -1189,7 +1195,8 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
             {
                 'quantity': 'RMS Slope',
                 'direction': 'x',
-                'value': rms_slope_from_der(dh_dx),
+                'area_value': None,
+                'profile_value': rms_slope_from_der(dh_dx),  # TODO Correct?
                 'unit': 1,
             }
         ])

--- a/topobank/analysis/functions.py
+++ b/topobank/analysis/functions.py
@@ -1143,7 +1143,7 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
     try:
         unit = topography.info['unit']
         inverse_unit = '{}⁻¹'.format(unit)
-    except Exception:
+    except KeyError:
         unit = None
         inverse_unit = None
 
@@ -1209,7 +1209,7 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
                 'unit': inverse_unit,
             }
         ])
-    # else:  # TODO Should this also be done for 2D? But .rms_curvature_from_profile does not exist in this case
+    # else:  # .rms_curvature_from_profile() does not exist for uniform line scans (so far)
     #     result.append({
     #         'quantity': 'RMS curvature',
     #         'from': FROM_1D,
@@ -1246,7 +1246,7 @@ def rms_values(topography, progress_recorder=None, storage_prefix=None):
                 'quantity': 'RMS gradient',
                 'from': FROM_2D,
                 'symbol': '',
-                'direction': '',
+                'direction': None,
                 'value': topography.rms_gradient(),
                 'unit': 1,
             },

--- a/topobank/analysis/tests/test_functions.py
+++ b/topobank/analysis/tests/test_functions.py
@@ -495,25 +495,74 @@ def test_rms_values(simple_linear_2d_topography):
     topography = FakeTopographyModel(simple_linear_2d_topography)
     result = rms_values(topography)
 
-    assert result[0]['quantity'] == 'RMS height'
-    assert result[0]['direction'] is None
-    assert np.isclose(result[0]['value_sq'], np.sqrt(33))
-    assert result[0]['unit'] == unit
+    expected = [
+        {
+            'quantity': 'RMS height',
+            'direction': 'x',
+            'from': 'profile (1D)',
+            'symbol': 'Rq',
+            'value': 0,
+            'unit': unit
+        },
+        {
+            'quantity': 'RMS height',
+            'direction': 'y',
+            'from': 'profile (1D)',
+            'symbol': 'Rq',
+            'value': 5.74456264,
+            'unit': unit
+        },
+        {
+            'quantity': 'RMS height',
+            'direction': None,
+            'from': 'area (2D)',
+            'symbol': 'Sq',
+            'value': np.sqrt(33),
+            'unit': unit
+        },
+        {
+            'quantity': 'RMS curvature',
+            'direction': None,
+            'from': 'area (2D)',
+            'symbol': '',
+            'value': 0,
+            'unit': inverse_unit,
+        },
+        {
+            'quantity': 'RMS slope',
+            'direction': 'x',
+            'from': 'profile (1D)',
+            'symbol': 'R&Delta;q',
+            'value': 0,
+            'unit': 1,
+        },
+        {
+            'quantity': 'RMS slope',
+            'direction': 'y',
+            'from': 'profile (1D)',
+            'symbol': 'R&Delta;q',
+            'value': 2,
+            'unit': 1,
+        },
+        {
+            'quantity': 'RMS gradient',
+            'direction': None,
+            'from': 'area (2D)',
+            'symbol': '',
+            'value': 2,
+            'unit': 1,
+        },
+    ]
 
-    assert result[1]['quantity'] == 'RMS curvature'
-    assert result[1]['direction'] is None
-    assert np.isclose(result[1]['value_sq'], 0)
-    assert result[1]['unit'] == inverse_unit
+    # compare all fields
+    for exp, actual in zip(expected, result):
+        assert_allclose(exp['value'], actual['value'],
+                        atol=1e-15,
+                        err_msg=f"Different values: exp: {exp}, actual: {actual}")
+        del exp['value']
+        del actual['value']
+        assert exp == actual
 
-    assert result[2]['quantity'] == 'RMS gradient'
-    assert result[2]['direction'] == 'x'
-    assert np.isclose(result[2]['value'], 0)
-    assert result[2]['unit'] == 1
-
-    assert result[3]['quantity'] == 'RMS gradient'
-    assert result[3]['direction'] == 'y'
-    assert np.isclose(result[3]['value'], 2)
-    assert result[3]['unit'] == 1
 
 
 ###############################################################################

--- a/topobank/analysis/tests/test_functions.py
+++ b/topobank/analysis/tests/test_functions.py
@@ -495,22 +495,22 @@ def test_rms_values(simple_linear_2d_topography):
     topography = FakeTopographyModel(simple_linear_2d_topography)
     result = rms_values(topography)
 
-    assert result[0]['quantity'] == 'RMS Height'
+    assert result[0]['quantity'] == 'RMS height'
     assert result[0]['direction'] is None
-    assert np.isclose(result[0]['value'], np.sqrt(33))
+    assert np.isclose(result[0]['value_sq'], np.sqrt(33))
     assert result[0]['unit'] == unit
 
-    assert result[1]['quantity'] == 'RMS Curvature'
+    assert result[1]['quantity'] == 'RMS curvature'
     assert result[1]['direction'] is None
-    assert np.isclose(result[1]['value'], 0)
+    assert np.isclose(result[1]['value_sq'], 0)
     assert result[1]['unit'] == inverse_unit
 
-    assert result[2]['quantity'] == 'RMS Slope'
+    assert result[2]['quantity'] == 'RMS gradient'
     assert result[2]['direction'] == 'x'
     assert np.isclose(result[2]['value'], 0)
     assert result[2]['unit'] == 1
 
-    assert result[3]['quantity'] == 'RMS Slope'
+    assert result[3]['quantity'] == 'RMS gradient'
     assert result[3]['direction'] == 'y'
     assert np.isclose(result[3]['value'], 2)
     assert result[3]['unit'] == 1

--- a/topobank/analysis/tests/test_results_view.py
+++ b/topobank/analysis/tests/test_results_view.py
@@ -607,25 +607,29 @@ def test_rms_values_rounded(rf, mocker):
         {
             'quantity': 'RMS Height',
             'direction': None,
-            'value': np.float32(1.2345678),
+            'value_sq': np.float32(1.2345678),
+            'value_rq': np.float32(8.7654321),
             'unit': 'm',
         },
         {
             'quantity': 'RMS Curvature',
             'direction': None,
-            'value': np.float32(0.9),
+            'value_sq': np.float32(0.9),
+            'value_rq': np.float32(9.87654321),
             'unit': '1/m',
         },
         {
             'quantity': 'RMS Slope',
             'direction': 'x',
-            'value': np.float32(-1.56789),
+            'value_rq': np.float32(-1.56789),
+            'value_sq': None,
             'unit': 1,
         },
         {
             'quantity': 'RMS Slope',
             'direction': 'y',
-            'value': np.float32('nan'),
+            'value_rq': np.float32('nan'),
+            'value_sq': None,
             'unit': 1,
         }
     ]
@@ -652,12 +656,14 @@ def test_rms_values_rounded(rf, mocker):
     # we want rounding to 5 digits
     assert NUM_SIGNIFICANT_DIGITS_RMS_VALUES == 5
     assert b"1.2346" in response.content
+    assert b"8.7654" in response.content
     assert b"0.9" in response.content
+    assert b"9.8765" in response.content
     assert b"-1.5679" in response.content
     assert b"NaN" in response.content
 
 
-@pytest.mark.parametrize("same_names", [ False, True])
+@pytest.mark.parametrize("same_names", [False, True])
 @pytest.mark.django_db
 def test_analysis_download_as_xlsx(client, two_topos, ids_downloadable_analyses, same_names, settings, handle_usage_statistics):
 

--- a/topobank/analysis/tests/test_results_view.py
+++ b/topobank/analysis/tests/test_results_view.py
@@ -570,9 +570,9 @@ def test_rms_table_download_as_txt(client, two_topos, file_format, handle_usage_
         txt = response.content.decode()
 
         assert "RMS Values" in txt  # function name should be in there
-        assert "RMS Height" in txt
-        assert "RMS Slope" in txt
-        assert "RMS Curvature" in txt
+        assert "RMS height" in txt
+        assert "RMS slope" in txt
+        assert "RMS curvature" in txt
     else:
         # Resulting workbook should have two sheets
         tmp = tempfile.NamedTemporaryFile(suffix='.xlsx')  # will be deleted automatically
@@ -589,9 +589,9 @@ def test_rms_table_download_as_txt(client, two_topos, file_format, handle_usage_
 
         all_values_list = list(np.array(list(ws.values)).flatten())
 
-        assert 'RMS Height' in all_values_list
-        assert 'RMS Slope' in all_values_list
-        assert 'RMS Curvature' in all_values_list
+        assert 'RMS height' in all_values_list
+        assert 'RMS slope' in all_values_list
+        assert 'RMS curvature' in all_values_list
 
         xlsx.get_sheet_by_name("INFORMATION")
 

--- a/topobank/analysis/tests/test_results_view.py
+++ b/topobank/analysis/tests/test_results_view.py
@@ -607,29 +607,41 @@ def test_rms_values_rounded(rf, mocker):
         {
             'quantity': 'RMS Height',
             'direction': None,
-            'value_sq': np.float32(1.2345678),
-            'value_rq': np.float32(8.7654321),
+            'from': 'area (2D)',
+            'symbol': 'Sq',
+            'value': np.float32(1.2345678),
+            'unit': 'm',
+        },
+        {
+            'quantity': 'RMS Height',
+            'direction': 'x',
+            'from': 'profile (1D)',
+            'symbol': 'Rq',
+            'value': np.float32(8.7654321),
             'unit': 'm',
         },
         {
             'quantity': 'RMS Curvature',
             'direction': None,
-            'value_sq': np.float32(0.9),
-            'value_rq': np.float32(9.87654321),
+            'from': 'profile (1D)',
+            'symbol': '',
+            'value': np.float32(0.9),
             'unit': '1/m',
         },
         {
             'quantity': 'RMS Slope',
             'direction': 'x',
-            'value_rq': np.float32(-1.56789),
-            'value_sq': None,
+            'from': 'profile (1D)',
+            'symbol': 'S&Delta;q',
+            'value': np.float32(-1.56789),
             'unit': 1,
         },
         {
             'quantity': 'RMS Slope',
             'direction': 'y',
-            'value_rq': np.float32('nan'),
-            'value_sq': None,
+            'from': 'profile (1D)',
+            'symbol': 'S&Delta;q',
+            'value': np.float32('nan'),
             'unit': 1,
         }
     ]
@@ -658,7 +670,6 @@ def test_rms_values_rounded(rf, mocker):
     assert b"1.2346" in response.content
     assert b"8.7654" in response.content
     assert b"0.9" in response.content
-    assert b"9.8765" in response.content
     assert b"-1.5679" in response.content
     assert b"NaN" in response.content
 

--- a/topobank/analysis/views.py
+++ b/topobank/analysis/views.py
@@ -981,11 +981,25 @@ class RMSTable(tables.Table):
                                accessor='topography__name')
     quantity = tables.Column()
     direction = tables.Column()
-    value = tables.Column()
+    area_value = tables.Column()
+    profile_value = tables.Column()
     unit = tables.Column()
 
 
 class RmsTableCardView(SimpleCardView):
+
+    @staticmethod
+    def _convert_value(v):
+        if v is not None:
+            if math.isnan(v):
+                v = None  # will be interpreted as null in JS, replace there with NaN!
+                # It's not easy to pass NaN as JSON:
+                # https://stackoverflow.com/questions/15228651/how-to-parse-json-string-containing-nan-in-node-js
+            else:
+                # convert float32 to float, round to fixed number of significant digits
+                v = round_to_significant_digits(v.astype(float),
+                                                NUM_SIGNIFICANT_DIGITS_RMS_VALUES)
+        return v
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -997,14 +1011,9 @@ class RmsTableCardView(SimpleCardView):
             analysis_result = analysis.result_obj
 
             for d in analysis_result:
-                if math.isnan(d['value']):
-                    d['value'] = None  # will be interpreted as null in JS, replace there with NaN!
-                    # It's not easy to pass NaN as JSON:
-                    # https://stackoverflow.com/questions/15228651/how-to-parse-json-string-containing-nan-in-node-js
-                else:
-                    # convert float32 to float, round to fixed number of significant digits
-                    d['value'] = round_to_significant_digits(d['value'].astype(float),
-                                                             NUM_SIGNIFICANT_DIGITS_RMS_VALUES)
+
+                d['area_value'] = self._convert_value(d['area_value'])
+                d['profile_value'] = self._convert_value(d['profile_value'])
 
                 if not d['direction']:
                     d['direction'] = ''

--- a/topobank/analysis/views.py
+++ b/topobank/analysis/views.py
@@ -1036,8 +1036,6 @@ class RmsTableCardView(SimpleCardView):
         #
         # create table
         #
-        # table = RMSTable(data=data, empty_text="No RMS values calculated.", request=self.request)
-
         context.update(dict(
             table_data=data
         ))

--- a/topobank/analysis/views.py
+++ b/topobank/analysis/views.py
@@ -976,16 +976,6 @@ class ContactMechanicsCardView(SimpleCardView):
         return context
 
 
-class RMSTable(tables.Table):
-    topography = tables.Column(linkify=lambda **kwargs: kwargs['record']['topography'].get_absolute_url(),
-                               accessor='topography__name')
-    quantity = tables.Column()
-    direction = tables.Column()
-    area_value = tables.Column()
-    profile_value = tables.Column()
-    unit = tables.Column()
-
-
 class RmsTableCardView(SimpleCardView):
 
     @staticmethod
@@ -1011,12 +1001,15 @@ class RmsTableCardView(SimpleCardView):
             analysis_result = analysis.result_obj
 
             for d in analysis_result:
-
-                d['area_value'] = self._convert_value(d['area_value'])
-                d['profile_value'] = self._convert_value(d['profile_value'])
+                d['value'] = self._convert_value(d['value'])
 
                 if not d['direction']:
                     d['direction'] = ''
+                if not d['from']:
+                    d['from'] = ''
+                if not d['symbol']:
+                    d['symbol'] = ''
+
                 # put topography in every line
                 topo = analysis.subject
                 d.update(dict(topography_name=topo.name,

--- a/topobank/templates/analysis/rmstable_card_datatables.html
+++ b/topobank/templates/analysis/rmstable_card_datatables.html
@@ -38,7 +38,8 @@
         },
         {data: 'quantity', title: 'Quantity'},
         {data: 'direction', title: 'Direction'},
-        {data: 'value', title: 'Value'},
+        {data: 'area_value', title: 'Value S<sub>q</sub>'},
+        {data: 'profile_value', title: 'Value R<sub>q</sub>'},
         {data: 'unit', title: 'Unit'},
       ],
       responsive: true

--- a/topobank/templates/analysis/rmstable_card_datatables.html
+++ b/topobank/templates/analysis/rmstable_card_datatables.html
@@ -40,7 +40,7 @@
         {data: 'from', title: 'From'},
         {data: 'symbol', title: 'Symbol'},
         {data: 'direction', title: 'Direction'},
-        {data: 'value', title: 'Value'},
+        {data: 'value', title: 'Value', render: function (x) { return format_exponential(x, 5);}},
         {data: 'unit', title: 'Unit'},
       ],
       responsive: true

--- a/topobank/templates/analysis/rmstable_card_datatables.html
+++ b/topobank/templates/analysis/rmstable_card_datatables.html
@@ -37,9 +37,10 @@
           }
         },
         {data: 'quantity', title: 'Quantity'},
+        {data: 'from', title: 'From'},
+        {data: 'symbol', title: 'Symbol'},
         {data: 'direction', title: 'Direction'},
-        {data: 'area_value', title: 'Value S<sub>q</sub>'},
-        {data: 'profile_value', title: 'Value R<sub>q</sub>'},
+        {data: 'value', title: 'Value'},
         {data: 'unit', title: 'Unit'},
       ],
       responsive: true


### PR DESCRIPTION
The renaming of the analysis function will be done later: #653 .

Could you have a look:
- How can curvature values be calculated? The method `rms_curvature_from_profile` is not available for uniform line scans and for 2D data.
- When to use "RMS gradient" and "RMS Slope" as quantity names?
- Is the list of values correct and complete? See `functions.py`