### PR TITLE
MAINT: Remove scipy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - MAINT: Update for package SurfaceTopography (#911)
 - MAINT: Update for package ContactMechanics (#872)
 - MAINT: Update of django because of security issue
+- MAINT: Bumped NuMPI version to 0.3.1 and removed scipy
+  dependency (#917)
 
 ## 0.91.1 (2022-09-19)
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -465,8 +465,7 @@ TRACKED_DEPENDENCIES = [
     ('NuMPI', 'NuMPI.__version__'),
     ('muFFT', 'muFFT.version.description()'),
     ('topobank', 'topobank.__version__'),
-    ('numpy', 'numpy.__version__'),
-    ('scipy', 'scipy.__version__'),
+    ('numpy', 'numpy.__version__')
 ]
 # Extend tracked dependencies by Plugin apps
 for plugin_app in PLUGIN_APPS:

--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -1,6 +1,5 @@
 .PHONY: all check clean
 
-objects = $(wildcard *.in)
 outputs := local.txt production.txt
 setup_files := ../setup.cfg ../setup.py
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -281,10 +281,11 @@ mufft==0.23.1
     #   topobank (../setup.py)
 netcdf4==1.6.1
     # via topobank (../setup.py)
-numpi==0.3.0
+numpi==0.3.1
     # via
     #   contactmechanics
     #   surfacetopography
+    #   topobank (../setup.py)
 numpy==1.23.3
     # via
     #   bokeh
@@ -298,7 +299,6 @@ numpy==1.23.3
     #   numpi
     #   numpyencoder
     #   pandas
-    #   scipy
     #   surfacetopography
     #   topobank (../setup.py)
     #   xarray
@@ -456,8 +456,6 @@ requests-oauthlib==1.3.1
     # via django-allauth
 s3transfer==0.6.0
     # via boto3
-scipy==1.9.1
-    # via numpi
 selenium==3.141.0
     # via
     #   pytest-selenium

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -205,10 +205,11 @@ mufft==0.23.1
     #   topobank (../setup.py)
 netcdf4==1.6.1
     # via topobank (../setup.py)
-numpi==0.3.0
+numpi==0.3.1
     # via
     #   contactmechanics
     #   surfacetopography
+    #   topobank (../setup.py)
 numpy==1.23.3
     # via
     #   bokeh
@@ -222,7 +223,6 @@ numpy==1.23.3
     #   numpi
     #   numpyencoder
     #   pandas
-    #   scipy
     #   surfacetopography
     #   topobank (../setup.py)
     #   xarray
@@ -308,8 +308,6 @@ requests-oauthlib==1.3.1
     # via django-allauth
 s3transfer==0.6.0
     # via boto3
-scipy==1.9.1
-    # via numpi
 short-url==1.2.2
     # via topobank (../setup.py)
 six==1.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -202,6 +202,9 @@ install_requires =
     numpy>=1.22
     # incomplete string comparison in the numpy.core component in NumPy1.9.x
 
+    NuMPI>=0.3.1
+    # remove scipy dependency
+
     greenlet
     gevent
     gunicorn[gevent]>=20.1.0  # https://github.com/benoitc/gunicorn

--- a/topobank/context_processors.py
+++ b/topobank/context_processors.py
@@ -7,7 +7,6 @@ import json
 import bokeh
 import celery
 import numpy
-import scipy
 
 import SurfaceTopography, ContactMechanics, NuMPI, muFFT
 
@@ -43,9 +42,6 @@ def versions_processor(request):
         dict(module='NumPy',
              version=numpy.__version__,
              links={'Website': 'https://numpy.org/'}),
-        dict(module='SciPy',
-             version=scipy.__version__,
-             links={'Website': 'https://www.scipy.org/'}),
         dict(module='Django',
              version=django.__version__,
              links={'Website': 'https://www.djangoproject.com/'}),


### PR DESCRIPTION
This PR bumps NuMPI to 0.3.1 which has no longer a scipy dependency.