### PR TITLE
MAINT: increasing visibility of notification badge

### DIFF
--- a/topobank/frontend/scss/custom.scss
+++ b/topobank/frontend/scss/custom.scss
@@ -618,7 +618,7 @@ body.fixed-nav.sidebar-toggled #content-wrapper {
     margin-left: 0.75rem;
     top: 0.3rem;
     font-weight: 400;
-    font-size: 0.5rem;
+    font-size: 0.7rem;
 }
 
 @media (min-width: 768px) {

--- a/topobank/templates/base.html
+++ b/topobank/templates/base.html
@@ -126,7 +126,7 @@
                     {% if not request.user.is_anonymous %}
                         <li class="nav-item">
                             <a class="nav-link" id="help-dropdown" role="button" onclick="toggleNotificationNav()">
-                                {% live_notify_badge badge_class="badge badge-info badge-pill live_notify_badge" %}
+                                {% live_notify_badge badge_class="badge bg-info rouded-pill live_notify_badge" %}
                                 <i class="fa fa-bell"></i>
                             </a>
                         </li>


### PR DESCRIPTION
This fixes the tiny notification count in the navbar:

| Before| After |
| -- | --|
|  ![2024-01-17_20-43](https://github.com/ContactEngineering/topobank/assets/74186504/0a35e0d8-d8ec-4fa1-afb0-464daf7c268f) |  ![2024-01-17_20-43_1](https://github.com/ContactEngineering/topobank/assets/74186504/fc7698c3-67bc-4514-8b7f-525a293177ce) |

There were two issues:
- the code uses bootstrap-v4 components (not present)
- the font size in the custom.scss was to small (in my opinion)

Bootstrap-v5 is present because of the `bootstrap-vue-next` thing.