### PR TITLE
MAINT: configuring pre-commit hooks: flake8 & isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: '7.0.0'
+    hooks:
+    - id: flake8
+      name: flake8 (check python code style)
+  - repo: https://github.com/pycqa/isort
+    rev: '5.13.2'
+    hooks:
+      - id: isort
+        name: isort (check imports)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for *TopoBank*
 
+## 1.6.1 (not yet released)
+
+- MAINT: installing pre-commit to run linting before commits
+
 ## 1.6.0 (2024-01-22)
 
 - ENH: Return creation and modification time in API routes

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,34 @@ Running tests with py.test
 
 Or use run configurations in your IDE, e.g. in PyCharm.
 
+linting with pre-commit hooks
+-----------------------------
+
+We are testing the code quality in the test pipeline, if your code is not conform with flake8,
+the pipeline will fail.
+To prevent you from committing non-conform code, you can install pre-commit.
+`pre-commit` runs tests on your code befor the commit.
+Just install `pre-commit` with pip or your package manager.
+Then run:
+
+.. code-block:: bash
+
+    pre-commit install
+
+Thats all you really need to do!
+
+To run the `pre-commit` hooks by hand you can run:
+
+.. code-block:: bash
+
+    pre-commit run
+
+If you want to skip a pre-commit stage, i.e. flake8, run:
+
+.. code-block:: bash
+
+   SKIP=flake8 pre-commit run
+
 Docker
 ------
 


### PR DESCRIPTION
This configures `pre-commit` to run `flake8` and `isort` test  before each commit, preventing developers to break those guidelines.
More on this [here](https://pre-commit.com/).

*Usage:*
1. install `pre-commit`
2. run `pre-commit install` inside the repo
3. run `pre-commit run` to run pre-commit hooks

`pre-commit` automatically runs before every commit.
It only runs on the **staged changes** and is no replacement for the CI checks!