### PR TITLE
add data_urls to analysis controller to fix spa redirect cors issue

### DIFF
--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -258,6 +258,20 @@ class Analysis(TaskStateModel):
                 "This `Analysis` does not have an id yet; the storage prefix is not yet known."
             )
         return "analyses/{}".format(self.id)
+    
+    @property
+    def storage_files(self):
+        """Return all file names in analysis id directory.
+
+        List of files names ['<file_prefix_name>/file'].
+        If storage is on filesystem, the prefix should correspond
+        to a real directory.
+        """
+        if self.id is None:
+            raise RuntimeError('This `Analysis` does not have an id yet; the storage file names is not yet known.')
+        dir_tuple = default_storage.listdir(f'analyses/{self.id}')
+        file_lists = dir_tuple[1]
+        return [f'{self.storage_prefix}/{file_name}' for file_name in file_lists]
 
     def get_related_surfaces(self):
         """Returns sequence of surface instances related to the subject of this analysis."""

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -258,7 +258,7 @@ class Analysis(TaskStateModel):
                 "This `Analysis` does not have an id yet; the storage prefix is not yet known."
             )
         return "analyses/{}".format(self.id)
-    
+
     @property
     def storage_files(self):
         """Return all file names in analysis id directory.

--- a/topobank/analysis/serializers.py
+++ b/topobank/analysis/serializers.py
@@ -72,7 +72,7 @@ class AnalysisResultSerializer(topobank.taskapp.serializers.TaskStateModelSerial
 
     def get_data_prefix(self, obj):
         return reverse('analysis:data', args=(obj.id, ''), request=self.context['request'])
-    
+
     def get_data_urls(self, obj):
         file_dir = {}
         for file_path in obj.storage_files:

--- a/topobank/analysis/serializers.py
+++ b/topobank/analysis/serializers.py
@@ -2,6 +2,7 @@ import logging
 
 from rest_framework import serializers
 from rest_framework.reverse import reverse
+from django.core.files.storage import default_storage
 
 import topobank.taskapp.serializers
 
@@ -59,11 +60,11 @@ class AnalysisResultSerializer(topobank.taskapp.serializers.TaskStateModelSerial
         model = Analysis
         fields = ['id', 'url', 'function', 'subject', 'kwargs', 'task_progress', 'task_state', 'task_memory',
                   'creation_time', 'start_time', 'end_time', 'dois', 'configuration', 'duration', 'data_prefix',
-                  'error', 'data_prefix']
+                  'error', 'data_urls']
 
     url = serializers.HyperlinkedIdentityField(view_name='analysis:result-detail', read_only=True)
     data_prefix = serializers.SerializerMethodField()
-
+    data_urls = serializers.SerializerMethodField()
     configuration = serializers.HyperlinkedRelatedField(view_name='analysis:configuration-detail', read_only=True)
     function = serializers.HyperlinkedRelatedField(view_name='analysis:function-detail', read_only=True)
 
@@ -71,3 +72,11 @@ class AnalysisResultSerializer(topobank.taskapp.serializers.TaskStateModelSerial
 
     def get_data_prefix(self, obj):
         return reverse('analysis:data', args=(obj.id, ''), request=self.context['request'])
+    
+    def get_data_urls(self, obj):
+        file_dir = {}
+        for file_path in obj.storage_files:
+            file = file_path.split('/')[-1]
+            file_name, file_extension = file.rsplit('.', 1)
+            file_dir[file_name] = default_storage.url(file_path)
+        return file_dir


### PR DESCRIPTION
- fix spa cors issue on redirect for the PCAPlot, GCAPlot, and GPCPlots when requesting django analysis urls view.data.