### PR TITLE
BUG fixed user and org lookups causing error

### DIFF
--- a/topobank/organizations/views.py
+++ b/topobank/organizations/views.py
@@ -31,7 +31,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
         # Filter for specific user
         if user is not None:
-            qs = qs.filter(group__in=user.groups.all())
+            qs = qs.filter(group__user=user)
 
         # Return query set
         return qs.distinct()

--- a/topobank/users/views.py
+++ b/topobank/users/views.py
@@ -40,7 +40,7 @@ class UserViewSet(viewsets.ModelViewSet):
 
         # Filter for organization
         if organization is not None:
-            qs = qs.filter(group=organization.group)
+            qs = qs.filter(groups__organization=organization)
 
         # Return query set
         return qs


### PR DESCRIPTION
Calling users endpoint with `?organization=<id>` resulted in error. 
Calling organizations endpoint with `?user=<id>` also resulted in error.

Fixed both cases