### PR TITLE
MAINT: Added username generation to user view

### DIFF
--- a/topobank/settings/base.py
+++ b/topobank/settings/base.py
@@ -699,3 +699,10 @@ DELETE_EXISTING_FILES = env.bool("TOPOBANK_DELETE_EXISTING_FILES", default=False
 # ------------------------------------------------------------------------------
 TOPOBANK_THUMBNAIL_FORMAT = "jpeg"  # File format for thumbnails
 TOPOBANK_DELETE_DELAY = timedelta(days=7)  # Hold deleted datasets this long
+
+
+# ALLAUTH SETTINGS
+# ------------------------------------------------------------------------------
+ACCOUNT_USERNAME_REQUIRED = True
+USER_MODEL_USERNAME_FIELD = "username"
+USERNAME_MIN_LENGTH = 3

--- a/topobank/users/admin.py
+++ b/topobank/users/admin.py
@@ -33,9 +33,38 @@ class MyUserCreationForm(UserCreationForm):
 class MyUserAdmin(AuthUserAdmin):
     form = MyUserChangeForm
     add_form = MyUserCreationForm
-    fieldsets = (("User profile", {"fields": ("name",)}),) + AuthUserAdmin.fieldsets
+    fieldsets = (
+        ("User profile", {"fields": ("name",)}),
+        (None, {"fields": ("username", "password")}),
+        ("Personal info", {"fields": ("first_name", "last_name", "email")}),
+        (
+            "Permissions",
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": ("username", "password1", "password2"),
+            },
+        ),
+        ("User profile", {"fields": ("name",)}),
+        ("Personal info", {"fields": ("first_name", "last_name", "email")}),
+    )
     list_display = ("id", "username", "name", "is_superuser", "orcid_uri")
     search_fields = ["name"]
+    readonly_fields = ["last_login", "date_joined"]
 
     @admin.display(description="ORCID URI")
     def orcid_uri(self, user):

--- a/topobank/users/views.py
+++ b/topobank/users/views.py
@@ -1,3 +1,4 @@
+from allauth.utils import generate_unique_username
 from django.db.models import Q
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404
@@ -47,6 +48,17 @@ class UserViewSet(viewsets.ModelViewSet):
 
         # Return query set
         return qs
+
+    def create(self, request, *args, **kwargs):
+        data: dict = request.data
+        if data.get("username"):
+            username = data.pop("username")
+        else:
+            username = generate_unique_username([data.get("email"), data.get("name")])
+        serializer = self.get_serializer(data={**data, "username": username})
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=201)
 
 
 def get_user_and_organization(request, pk):


### PR DESCRIPTION
Added create method to UserViewSet

Uses django-allauth to generate unique username for the user.
Optionally a username can be passed in, but will receive a 400 response if that username is taken.

Also,
Fixed admin user creation error