### PR TITLE
BUG: Provide either `id` or `url`

### DIFF
--- a/topobank/supplib/serializers.py
+++ b/topobank/supplib/serializers.py
@@ -649,13 +649,6 @@ class OrganizationField(ModelRelatedField):
             ]
         }
 
-    Input for deserialization::
-
-        {
-            "name": "New Project",
-            "owner_organization": {"id": 5}
-        }
-
     Notes
     -----
     - This field is pre-configured to use the 'organizations:organization-v1-detail' view name


### PR DESCRIPTION
For `RelatedModelFields` we need to accept a dictionary that has either an id or a url of the form:

`{ id: 1 }` OR `{ url: 'https://xxx' }` -- if both are provided, there is a check whether they refer to the same object