### PR TITLE
BUG: Fixed tag_startswith to work on tags with spaces

### DIFF
--- a/topobank/manager/filters.py
+++ b/topobank/manager/filters.py
@@ -52,8 +52,9 @@ class TopographyViewFilterSet(FilterSet):
         """
         Filter by tag path starting with substring (case-insensitive).
         """
+        path = value.replace(" ", "-")
         return queryset.filter(
-            surface__tags__path__istartswith=value
+            surface__tags__path__istartswith=path
         ).distinct()
 
 


### PR DESCRIPTION
Fixed bug that caused tags with spaces in name to not return surfaces below them when filtering