### PR TITLE
BUG: Fix manifest permissions to create permission set

### DIFF
--- a/topobank/files/v2/serializers.py
+++ b/topobank/files/v2/serializers.py
@@ -98,7 +98,7 @@ class ManifestV2CreateSerializer(StrictFieldMixin, serializers.HyperlinkedModelS
             # TODO: consider allowing permissions object to be passed in request
             # so it can be tied to surface/topography
             validated_data['permissions'] = PermissionSet.objects.create()
-            validated_data['permissions'].grant_permission(
+            validated_data['permissions'].grant(
                 self.context['request'].user, FULL
             )
 


### PR DESCRIPTION
I removed the manager auto-create permission set objects since the manager is not always used to create objects. This led to inconsistent permission management.

I forgot to fix this instance after removing that.