### PR TITLE
BUG: Fixed user queryset not being distinct

### DIFF
--- a/topobank/users/views.py
+++ b/topobank/users/views.py
@@ -39,10 +39,13 @@ class UserViewSet(viewsets.ModelViewSet):
                 | Q(groups__in=self.request.user.groups.all())
             )
 
-        # Filter for name
-        # TODO: query name, username, email together
+        # Filter for name, username, or email
         if name is not None:
-            qs = qs.filter(name__icontains=name)
+            qs = qs.filter(
+                Q(name__icontains=name)
+                | Q(username__icontains=name)
+                | Q(email__icontains=name)
+            )
 
         # Filter for organization
         if organization is not None:


### PR DESCRIPTION
Fix for the following error that occurs when a user is in multiple groups and the user queryset not setting distinct.

```
Internal Server Error: /users/v1/user/6/
--
Traceback (most recent call last):
File "/venv/lib/python3.12/site-packages/asgiref/sync.py", line 489, in thread_handler
raise exc_info[1]
File "/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 42, in inner
response = await get_response(request)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/asgiref/sync.py", line 489, in thread_handler
raise exc_info[1]
File "/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 253, in _get_response_async
response = await wrapped_callback(
^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/asgiref/sync.py", line 439, in __call__
ret = await asyncio.shield(exec_coro)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/asgiref/current_thread_executor.py", line 40, in run
result = self.fn(*self.args, **self.kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/asgiref/sync.py", line 493, in thread_handler
return func(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
return func(*args, **kwds)
^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
return view_func(request, *args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
return self.dispatch(request, *args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
response = self.handle_exception(exc)
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
self.raise_uncaught_exception(exc)
File "/venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
raise exc
File "/venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
response = handler(request, *args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/mixins.py", line 54, in retrieve
instance = self.get_object()
^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/generics.py", line 100, in get_object
obj = get_object_or_404(queryset, **filter_kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/rest_framework/generics.py", line 19, in get_object_or_404
return _get_object_or_404(queryset, *filter_args, **filter_kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/django/shortcuts.py", line 90, in get_object_or_404
return queryset.get(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.12/site-packages/django/db/models/query.py", line 638, in get
raise self.model.MultipleObjectsReturned(
topobank.users.models.User.MultipleObjectsReturned: get() returned more than one User -- it returned 2!

```