### PR TITLE
BUG: Fixed bug where deleted topos were returned if surface was not d…

### DIFF
--- a/topobank/manager/v2/views.py
+++ b/topobank/manager/v2/views.py
@@ -91,7 +91,7 @@ class TopographyViewSet(UserUpdateMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         return Topography.objects.for_user(self.request.user).filter(
-            Q(deletion_time__isnull=True) | Q(surface__deletion_time__isnull=True)
+            Q(deletion_time__isnull=True) & Q(surface__deletion_time__isnull=True)
         ).select_related(
             'surface',
             'permissions',


### PR DESCRIPTION
Queryset was returning topographies if they had not been deleted OR the surface had not been deleted. This caused a deleted topography to be returned because its surface still existed.

Updated the filter to use AND operator