### PR TITLE
SD-670: BUG: Clear task_start/end_time when setting pending

### DIFF
--- a/tests/taskapp/test_set_pending_state.py
+++ b/tests/taskapp/test_set_pending_state.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for TaskStateModel.set_pending_state in taskapp/models.py
+
+Re-pending a task (e.g. when a dependency is recomputed) must reset the row so
+it looks freshly created. In particular the timestamps from any prior run have
+to be cleared, otherwise task_duration reports garbage and a stale
+task_start_time could be mistaken for an in-flight run.
+"""
+import datetime
+
+import pytest
+
+from topobank.analysis.models import WorkflowResult
+from topobank.testing.factories import TopographyAnalysisFactory
+
+
+@pytest.mark.django_db
+class TestSetPendingState:
+    """Tests for TaskStateModel.set_pending_state"""
+
+    def test_clears_timestamps(self, test_workflow):
+        """Both run timestamps are reset so the re-pended row looks fresh."""
+        analysis = TopographyAnalysisFactory(
+            task_state=WorkflowResult.SUCCESS,
+            task_start_time=datetime.datetime(2018, 1, 1, 12),
+            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            workflow_name=test_workflow.name,
+        )
+
+        analysis.set_pending_state()
+
+        assert analysis.task_start_time is None
+        assert analysis.task_end_time is None
+
+        # ...and the reset is persisted, not just held in memory.
+        analysis.refresh_from_db()
+        assert analysis.task_start_time is None
+        assert analysis.task_end_time is None
+
+    def test_task_duration_is_none_after_repend(self, test_workflow):
+        """duration() must not report a stale value from the previous run."""
+        analysis = TopographyAnalysisFactory(
+            task_state=WorkflowResult.SUCCESS,
+            task_start_time=datetime.datetime(2018, 1, 1, 12),
+            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            workflow_name=test_workflow.name,
+        )
+        # Sanity check: the analysis has a duration before re-pending.
+        assert analysis.task_duration == datetime.timedelta(hours=1)
+
+        analysis.set_pending_state()
+
+        assert analysis.task_duration is None
+
+    def test_resets_state_and_clears_error_fields(self, test_workflow):
+        """The remaining bookkeeping fields are reset alongside the timestamps."""
+        analysis = TopographyAnalysisFactory(
+            task_state=WorkflowResult.FAILURE,
+            task_id="some-stale-celery-id",
+            task_error="boom",
+            task_traceback="Traceback (most recent call last): ...",
+            workflow_name=test_workflow.name,
+        )
+
+        analysis.set_pending_state()
+        analysis.refresh_from_db()
+
+        assert analysis.task_state == WorkflowResult.PENDING
+        assert analysis.task_id is None
+        assert analysis.task_error == ""
+        assert analysis.task_traceback is None
+        assert analysis.task_submission_time is not None
+
+    def test_autosave_false_does_not_persist(self, test_workflow):
+        """With autosave=False the in-memory row is reset but the DB is untouched."""
+        analysis = TopographyAnalysisFactory(
+            task_state=WorkflowResult.SUCCESS,
+            task_start_time=datetime.datetime(2018, 1, 1, 12),
+            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            workflow_name=test_workflow.name,
+        )
+
+        analysis.set_pending_state(autosave=False)
+
+        # In-memory instance reflects the reset...
+        assert analysis.task_start_time is None
+        assert analysis.task_end_time is None
+        assert analysis.task_state == WorkflowResult.PENDING
+
+        # ...but nothing was written, so the database still has the old values.
+        analysis.refresh_from_db()
+        assert analysis.task_start_time is not None
+        assert analysis.task_end_time is not None
+        assert analysis.task_state == WorkflowResult.SUCCESS

--- a/tests/taskapp/test_set_pending_state.py
+++ b/tests/taskapp/test_set_pending_state.py
@@ -7,11 +7,15 @@ to be cleared, otherwise task_duration reports garbage and a stale
 task_start_time could be mistaken for an in-flight run.
 """
 import datetime
+import uuid
 
 import pytest
 
 from topobank.analysis.models import WorkflowResult
 from topobank.testing.factories import TopographyAnalysisFactory
+
+START_TIME = datetime.datetime(2018, 1, 1, 12, tzinfo=datetime.timezone.utc)
+END_TIME = datetime.datetime(2018, 1, 1, 13, tzinfo=datetime.timezone.utc)
 
 
 @pytest.mark.django_db
@@ -22,8 +26,8 @@ class TestSetPendingState:
         """Both run timestamps are reset so the re-pended row looks fresh."""
         analysis = TopographyAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
-            task_start_time=datetime.datetime(2018, 1, 1, 12),
-            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            task_start_time=START_TIME,
+            task_end_time=END_TIME,
             workflow_name=test_workflow.name,
         )
 
@@ -41,8 +45,8 @@ class TestSetPendingState:
         """duration() must not report a stale value from the previous run."""
         analysis = TopographyAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
-            task_start_time=datetime.datetime(2018, 1, 1, 12),
-            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            task_start_time=START_TIME,
+            task_end_time=END_TIME,
             workflow_name=test_workflow.name,
         )
         # Sanity check: the analysis has a duration before re-pending.
@@ -56,7 +60,7 @@ class TestSetPendingState:
         """The remaining bookkeeping fields are reset alongside the timestamps."""
         analysis = TopographyAnalysisFactory(
             task_state=WorkflowResult.FAILURE,
-            task_id="some-stale-celery-id",
+            task_id=str(uuid.uuid4()),
             task_error="boom",
             task_traceback="Traceback (most recent call last): ...",
             workflow_name=test_workflow.name,
@@ -75,8 +79,8 @@ class TestSetPendingState:
         """With autosave=False the in-memory row is reset but the DB is untouched."""
         analysis = TopographyAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
-            task_start_time=datetime.datetime(2018, 1, 1, 12),
-            task_end_time=datetime.datetime(2018, 1, 1, 13),
+            task_start_time=START_TIME,
+            task_end_time=END_TIME,
             workflow_name=test_workflow.name,
         )
 

--- a/topobank/taskapp/models.py
+++ b/topobank/taskapp/models.py
@@ -400,6 +400,11 @@ class TaskStateModel(models.Model):
         self.task_error = ""
         self.task_traceback = None
         self.task_id = None  # Need to reset, otherwise Celery reports a failure
+        # Clear timestamps from any prior run so a re-pended row looks freshly
+        # created: otherwise duration() reports garbage and a stale task_start_time
+        # could be mistaken for an in-flight run.
+        self.task_start_time = None
+        self.task_end_time = None
         if autosave:
             self.save(
                 update_fields=[
@@ -408,6 +413,8 @@ class TaskStateModel(models.Model):
                     "task_error",
                     "task_traceback",
                     "task_id",
+                    "task_start_time",
+                    "task_end_time",
                 ]
             )
 


### PR DESCRIPTION
When a task is re-submitted, the old task_start_time/task_end_time are never reset. This fixes that so time tracking is accurate.