### PR TITLE
SD-668: BUG: Fixed refresh_cache() being called multiple times per upload

### DIFF
--- a/tests/manager/test_deepzoom.py
+++ b/tests/manager/test_deepzoom.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from topobank.testing.factories import Topography2DFactory
@@ -17,3 +19,29 @@ def test_deepzoom_creation_fails(mocker):
     topo.refresh_cache()
     # should have no deepzoom images
     assert topo.deepzoom is None
+
+
+@pytest.mark.django_db
+def test_missing_thumbnail_is_logged_but_not_fatal(mocker, caplog):
+    """A failed thumbnail stays non-fatal but is surfaced via an ERROR log."""
+    topo = Topography2DFactory(size_x=1, size_y=1)
+
+    mocker.patch(
+        "topobank.manager.models.Topography._make_thumbnail",
+        side_effect=Exception("Test exception"),
+    )
+
+    with caplog.at_level(logging.ERROR, logger="topobank.manager.models"):
+        topo.refresh_cache()  # must not raise
+
+    # Generation stayed resilient: thumbnail cleared, no exception propagated.
+    assert topo.thumbnail is None
+    # ...but the failure is now observable: both the make_thumbnail handler and
+    # the end-of-refresh verification block log at ERROR mentioning "thumbnail".
+    assert any(
+        record.levelno == logging.ERROR and "thumbnail" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any(
+        "missing derived files" in record.getMessage() for record in caplog.records
+    )

--- a/tests/taskapp/test_run_task_guard.py
+++ b/tests/taskapp/test_run_task_guard.py
@@ -6,6 +6,7 @@ causing concurrent ``refresh_cache`` executions on the same measurement.
 """
 
 import pytest
+from django.core.management import call_command
 
 from topobank.manager.models import Topography
 from topobank.taskapp.models import TaskStateModel
@@ -93,3 +94,21 @@ def test_factory_path_still_dispatches():
     # transparent there (state is NOTRUN), so derived files are present.
     assert topo.thumbnail is not None
     assert topo.squeezed_datafile is not None
+
+
+@pytest.mark.django_db
+def test_refresh_cache_command_background_persists_pending_state():
+    """`refresh_cache --background` must leave the DB showing the pending state.
+
+    run_task() only sets task_state in memory (autosave=False); without a save
+    the operator would keep seeing the stale prior state (e.g. SUCCESS) until a
+    worker starts. The command wraps run_task + save in a transaction, so the
+    DB reflects PENDING immediately.
+    """
+    topo = Topography1DFactory()
+    _set_state(topo, TaskStateModel.SUCCESS)
+
+    call_command("refresh_cache", "--background")
+
+    topo.refresh_from_db()
+    assert topo.task_state == TaskStateModel.PENDING

--- a/tests/taskapp/test_run_task_guard.py
+++ b/tests/taskapp/test_run_task_guard.py
@@ -1,0 +1,95 @@
+"""Tests for the in-flight dispatch guard in ``run_task``.
+
+These cover the regression where ``refresh_cache`` re-dispatched the task it was
+already running (because its terminal ``save()`` mutated significant fields),
+causing concurrent ``refresh_cache`` executions on the same measurement.
+"""
+
+import pytest
+
+from topobank.manager.models import Topography
+from topobank.taskapp.models import TaskStateModel
+from topobank.taskapp.utils import run_task
+from topobank.testing.factories import Topography1DFactory
+
+
+def _set_state(topo, state, **extra):
+    """Force task_state (and optional extra fields) directly in the DB."""
+    Topography.objects.filter(pk=topo.pk).update(task_state=state, **extra)
+    topo.refresh_from_db()
+
+
+@pytest.mark.django_db
+def test_run_task_skips_when_in_flight(mocker):
+    topo = Topography1DFactory()
+    _set_state(topo, TaskStateModel.STARTED)
+
+    spy = mocker.spy(topo, "set_pending_state")
+    run_task(topo)
+
+    # Guard short-circuited before set_pending_state; state untouched.
+    assert spy.call_count == 0
+    assert topo.task_state == TaskStateModel.STARTED
+
+
+@pytest.mark.django_db
+def test_run_task_force_overrides_in_flight(mocker):
+    topo = Topography1DFactory()
+    _set_state(topo, TaskStateModel.STARTED)
+
+    spy = mocker.spy(topo, "set_pending_state")
+    run_task(topo, force=True)
+
+    # force=True bypasses the guard and re-pends the task.
+    assert spy.call_count == 1
+    assert topo.task_state == TaskStateModel.PENDING
+
+
+@pytest.mark.django_db
+def test_run_task_dispatches_when_notrun(mocker):
+    topo = Topography1DFactory()
+    _set_state(topo, TaskStateModel.NOTRUN)
+
+    spy = mocker.spy(topo, "set_pending_state")
+    run_task(topo)
+
+    # NOTRUN is not an in-flight state, so the first dispatch proceeds.
+    assert spy.call_count == 1
+    assert topo.task_state == TaskStateModel.PENDING
+
+
+@pytest.mark.django_db
+def test_refresh_cache_does_not_redispatch_when_started(
+    django_capture_on_commit_callbacks,
+):
+    """Regression: a task running refresh_cache must not dispatch itself again.
+
+    The outer task sets task_state=STARTED before refresh_cache runs; the
+    terminal save() in refresh_cache then re-enters run_task. With the guard,
+    that re-entry is a no-op (no second celery dispatch, state stays STARTED).
+    """
+    topo = Topography1DFactory()
+    # Simulate the running task and clear a significant field so refresh_cache
+    # repopulates it -- pre-fix this is exactly what made the terminal save()
+    # re-dispatch a second, concurrent task.
+    _set_state(topo, TaskStateModel.STARTED, data_source=None)
+
+    with django_capture_on_commit_callbacks(execute=False) as callbacks:
+        topo.refresh_cache()
+
+    # No new celery dispatch was registered and the state was not reset.
+    assert callbacks == []
+    topo.refresh_from_db()
+    assert topo.task_state == TaskStateModel.STARTED
+    # ...but the refresh still did its work (significant field repopulated).
+    assert topo.data_source is not None
+
+
+@pytest.mark.django_db
+def test_factory_path_still_dispatches():
+    """The NOTRUN factory path is unchanged: derived files are still produced."""
+    topo = Topography1DFactory()
+    # Topography1DFactory calls refresh_cache() in post_generation; the guard is
+    # transparent there (state is NOTRUN), so derived files are present.
+    assert topo.thumbnail is not None
+    assert topo.squeezed_datafile is not None

--- a/topobank/manager/management/commands/refresh_cache.py
+++ b/topobank/manager/management/commands/refresh_cache.py
@@ -46,7 +46,11 @@ class Command(BaseCommand):
 
             try:
                 if options['background']:
-                    run_task(topo)
+                    # force=True: this is a deliberate operator recompute, so
+                    # re-dispatch even if a (possibly stale/stuck) task is
+                    # already in flight. Keeps parity with the non-background
+                    # branch, which calls refresh_cache() ignoring task state.
+                    run_task(topo, force=True)
                 else:
                     topo.refresh_cache()
                 num_success += 1

--- a/topobank/manager/management/commands/refresh_cache.py
+++ b/topobank/manager/management/commands/refresh_cache.py
@@ -2,6 +2,7 @@ import logging
 import traceback
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from topobank.manager.models import Topography
 from topobank.taskapp.utils import run_task
@@ -50,7 +51,15 @@ class Command(BaseCommand):
                     # re-dispatch even if a (possibly stale/stuck) task is
                     # already in flight. Keeps parity with the non-background
                     # branch, which calls refresh_cache() ignoring task state.
-                    run_task(topo, force=True)
+                    #
+                    # The transaction + save() persists the pending state so an
+                    # operator sees 'pending' immediately (run_task only sets it
+                    # in memory via autosave=False) and lets run_task's on_commit
+                    # dispatch fire after the pending state is committed -- the
+                    # same pattern as Topography.ensure_task_started().
+                    with transaction.atomic():
+                        run_task(topo, force=True)
+                        topo.save()
                 else:
                     topo.refresh_cache()
                 num_success += 1

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -1355,13 +1355,13 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
             if none_on_error:
                 self.thumbnail = None
                 self.save(update_fields=["thumbnail"])
-                _log.warning(
-                    f"Problems while generating thumbnail for topography {self.id}:"
-                    f" {exc}. Saving <None> instead."
+                _log.error(
+                    "Problems while generating thumbnail for topography %s: %s. "
+                    "Saving <None> instead.",
+                    self.id,
+                    exc,
+                    exc_info=True,
                 )
-                import traceback
-
-                _log.warning(f"Traceback: {traceback.format_exc()}")
             else:
                 raise ThumbnailGenerationException(self, str(exc)) from exc
 
@@ -1388,12 +1388,13 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
             if none_on_error:
                 self.deepzoom = None
                 self.save(update_fields=["deepzoom"])
-                _log.warning(
-                    f"Problems while generating deep zoom images for topography {self.id}: {exc}."
+                _log.error(
+                    "Problems while generating deep zoom images for topography "
+                    "%s: %s. Saving <None> instead.",
+                    self.id,
+                    exc,
+                    exc_info=True,
                 )
-                import traceback
-
-                _log.warning(f"Traceback: {traceback.format_exc()}")
             else:
                 raise DZIGenerationException(self, str(exc)) from exc
 
@@ -1404,13 +1405,13 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
             if none_on_error:
                 self.squeezed_datafile = None
                 self.save(update_fields=["squeezed_datafile"])
-                _log.warning(
+                _log.error(
                     "Problems while generating squeezed datafile for topography "
-                    f"{self.id}: {exc}. Saving <None> instead."
+                    "%s: %s. Saving <None> instead.",
+                    self.id,
+                    exc,
+                    exc_info=True,
                 )
-                import traceback
-
-                _log.warning(f"Traceback: {traceback.format_exc()}")
             else:
                 raise SqueezedDatafileGenerationException(self, str(exc)) from exc
 
@@ -1633,6 +1634,31 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
                     self.make_deepzoom(st_topo=st_topo)
                 with timer("make_squeezed"):
                     self.make_squeezed(st_topo=st_topo)
+
+                # Verify the derived files actually landed. A measurement with
+                # complete metadata is expected to have these; a missing one is
+                # a silent data-quality failure that would otherwise be masked
+                # by task_state=SUCCESS. We only log (generation stays
+                # non-fatal) so monitoring can catch it.
+                missing = []
+                if self.thumbnail is None or not self.thumbnail.exists():
+                    missing.append("thumbnail")
+                # deepzoom is only generated for 2D maps (size_y is not None)
+                if self.size_y is not None and (
+                    self.deepzoom is None or len(self.deepzoom) == 0
+                ):
+                    missing.append("deepzoom")
+                if self.squeezed_datafile is None or not (
+                    self.squeezed_datafile.exists()
+                ):
+                    missing.append("squeezed_datafile")
+                if missing:
+                    _log.error(
+                        "refresh_cache: topography %s has complete metadata but "
+                        "is missing derived files: %s",
+                        self.id,
+                        ", ".join(missing),
+                    )
 
         # Save dataset
         self.save()

--- a/topobank/taskapp/models.py
+++ b/topobank/taskapp/models.py
@@ -44,6 +44,11 @@ class TaskStateModel(models.Model):
         (NOTRUN, "not run"),
     )
 
+    # States indicating a task is dispatched or running. RETRY is deliberately
+    # excluded: a task awaiting retry is not currently running and keeps its
+    # original (now-stale) task_start_time.
+    IN_FLIGHT_STATES = (PENDING, PENDING_DEPENDENCIES, STARTED)
+
     # Mapping Celery states to our state information. Everything not in the
     # list (e.g. custom Celery states) are interpreted as STARTED.
     _CELERY_STATE_MAP = {

--- a/topobank/taskapp/utils.py
+++ b/topobank/taskapp/utils.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 import sys
 from functools import lru_cache
@@ -9,6 +10,8 @@ from django.db import transaction
 
 from .celeryapp import app
 from .models import Dependency, TaskStateModel, Version
+
+_log = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
@@ -178,8 +181,27 @@ def task_dispatch(celery_task, cls_id, obj_id, *args, **kwargs):
 
 
 def run_task(
-    model_instance: TaskStateModel, celery_queue: Optional[str] = None, *args, **kwargs
+    model_instance: TaskStateModel,
+    celery_queue: Optional[str] = None,
+    *args,
+    force: bool = False,
+    **kwargs,
 ):
+    # Guard against re-dispatching a task that is already in flight. This
+    # prevents the re-entrant dispatch that happens when `refresh_cache` mutates
+    # significant fields and its terminal `save()` re-enters `run_task` (the
+    # outer task has already set state to STARTED at that point), as well as
+    # duplicate dispatches from repeated webhook deliveries. Pass `force=True`
+    # to deliberately re-run an in-flight task (e.g. an operator recompute).
+    if not force and model_instance.task_state in TaskStateModel.IN_FLIGHT_STATES:
+        _log.debug(
+            "run_task: skipping dispatch for %s id=%s; task already in-flight "
+            "(state=%s). Pass force=True to override.",
+            type(model_instance).__name__,
+            model_instance.id,
+            model_instance.task_state,
+        )
+        return
     model_instance.set_pending_state(autosave=False)
     # Only submit this on_commit, once save() has finalized and everything
     # has been flushed to the database (including a possible 'pe'nding state)


### PR DESCRIPTION
## Fix: concurrent `refresh_cache` race causing silent missing thumbnails

### Problem

An uploaded topography could finish with `task_state = "success"` but **no thumbnail**. Logs for the affected measurement showed `refresh_cache` running ~3 times concurrently across different Celery workers (two overlapping in time), under two different trace IDs. The concurrent runs raced on thumbnail generation and one clobbered the other; other topographies in the same batch only survived by lucky timing.

### Root cause

**Re-entrant task dispatch.** `refresh_cache()` populates the model's *significant* fields (`data_source`, `size_x`, `size_y`, `unit`, `height_scale`, `is_periodic`) and then calls a bare `self.save()`. `Topography.save()` interprets those changed significant fields as a user edit and re-dispatches the task:

```python
# Topography.save()
if refresh_dependent_data:
    run_task(self)
```

The free `run_task()` had **no in-flight guard**, so the task that was *currently running* dispatched a second copy of itself. A duplicate S3 webhook delivery could add a third. The result was multiple concurrent `refresh_cache` executions racing on the non-atomic thumbnail write (delete-old → create-new → assign-FK, persisted only by the terminal save).

**Silent failure.** `make_thumbnail(none_on_error=True)` swallows exceptions and the outer `run_task` sets `task_state = SUCCESS` regardless, so a missing thumbnail never surfaced.

### Fix

**Bug 1 — in-flight dispatch guard (eliminates the concurrency):**
- `run_task()` now skips dispatch when the model is already in flight (`PENDING` / `PENDING_DEPENDENCIES` / `STARTED`), with a keyword-only `force=False` escape hatch. Because the outer task is `STARTED` when `refresh_cache`'s terminal `save()` re-enters `run_task`, the self-re-dispatch is suppressed — **exactly one task per upload**. This also collapses duplicate webhook deliveries.
- Added a canonical `TaskStateModel.IN_FLIGHT_STATES = (PENDING, PENDING_DEPENDENCIES, STARTED)` class attribute (no DB migration; `RETRY` deliberately excluded, consistent with the stale-task sweep).
- The `refresh_cache` management command (operator "recompute now" tool) passes `force=True` so it can still re-run a stuck/in-flight topography.

**Bug 2 — make silent failures observable (non-fatal):**
- `make_thumbnail` / `make_deepzoom` / `make_squeezed` now log at `ERROR` with `exc_info=True` (consolidating the previous WARNING + manual traceback). Generation stays resilient (`none_on_error=True` unchanged), consistent with the existing design (`test_deepzoom_creation_fails`).
- `refresh_cache` ends with a verification block that `ERROR`-logs any missing derived file when metadata is complete, so monitoring catches the case that produced this bug instead of it hiding behind `task_state=SUCCESS`.

### Files changed

| File | Change |
|------|--------|
| `topobank/taskapp/utils.py` | Module logger + in-flight guard + keyword-only `force` in `run_task()` |
| `topobank/taskapp/models.py` | `TaskStateModel.IN_FLIGHT_STATES` class attribute (no migration) |
| `topobank/manager/management/commands/refresh_cache.py` | Background branch calls `run_task(topo, force=True)` |
| `topobank/manager/models.py` | WARNING→ERROR in the three `make_*` wrappers; derived-file verification block in `refresh_cache` |
| `tests/taskapp/test_run_task_guard.py` | New: guard skip / force override / notrun dispatch, no-redispatch-when-started regression, factory path unchanged |
| `tests/manager/test_deepzoom.py` | New `test_missing_thumbnail_is_logged_but_not_fatal` |

### Testing

```
TOPOBANK_UPLOAD_METHOD=POST pytest tests/taskapp/test_run_task_guard.py tests/manager/test_deepzoom.py
```

- 7 targeted tests pass (5 new guard/regression tests + new thumbnail-logging test + existing `test_deepzoom_creation_fails`).
- The in-flight guard is transparent to the test factories: they call `refresh_cache()` with `task_state="no"` (NOTRUN), which is not an in-flight state, so behavior is unchanged and no recursion is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
