### PR TITLE
ENH: Schema for container metadata; dropped meta.yml (index.json still

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for *TopoBank*
 
+# Unreleased
+
+- ENH: Surface containers use a single pydantic-validated `index.json` metadata file
+- ENH: `export_container_zip` accepts optional opaque `extra_metadata` (`ContainerMeta.extra`)
+- MAINT: No longer write `meta.yml` to containers (legacy `meta.yml` still read on import)
+
 # 1.68.0 (2026-06-15)
 
 - ENH: Allow metadata to be passed on analysis POST
@@ -1477,4 +1483,3 @@ This release mainly implements a redesign of the user interface.
 - download of analysis results as png, xlsx, or text file
 - ask user for terms and conditions, also optional terms are possible
 - storage of topography files on S3 backend
-

--- a/tests/manager/test_containers.py
+++ b/tests/manager/test_containers.py
@@ -12,6 +12,7 @@ from notifications.models import Notification
 
 import topobank
 from topobank.manager.export_zip import export_container_zip
+from topobank.manager.import_zip import import_container_zip, load_container_metadata
 from topobank.manager.models import Surface, Topography
 from topobank.manager.tasks import import_container_from_url
 from topobank.testing.factories import (
@@ -177,3 +178,74 @@ def test_import():
         ).count()
         == 1
     )
+
+
+@pytest.mark.django_db
+def test_container_extra_metadata_roundtrip():
+    """Opaque ``extra_metadata`` is written verbatim and read back unchanged."""
+    user = UserFactory()
+    surfaces = [
+        SurfaceFactory(created_by=user, name="S0"),
+        SurfaceFactory(created_by=user, name="S1"),
+    ]
+    # Mimics what the SDS API will attach: training groups referencing surfaces
+    # by their index in the container.
+    extra = {"training_groups": [{"name": "Tiles 2024", "members": [0, 1]}]}
+
+    outfile = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    export_container_zip(outfile, surfaces, extra_metadata=extra)
+    outfile.close()
+
+    try:
+        with zipfile.ZipFile(outfile.name, mode="r") as zf:
+            meta = json.load(zf.open("index.json"))
+            assert meta["extra"] == extra
+            # ...and round-trips through the pydantic schema unchanged.
+            assert load_container_metadata(zf).extra == extra
+    finally:
+        os.remove(outfile.name)
+
+
+@pytest.mark.django_db
+def test_container_without_extra_metadata_omits_key():
+    """Without ``extra_metadata`` the ``extra`` key is absent (exclude_none)."""
+    user = UserFactory()
+    surface = SurfaceFactory(created_by=user, name="S0")
+
+    outfile = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    export_container_zip(outfile, [surface])
+    outfile.close()
+
+    try:
+        with zipfile.ZipFile(outfile.name, mode="r") as zf:
+            meta = json.load(zf.open("index.json"))
+            assert "extra" not in meta
+            assert load_container_metadata(zf).extra is None
+    finally:
+        os.remove(outfile.name)
+
+
+@pytest.mark.django_db
+def test_import_preserves_surface_order():
+    """import_container_zip returns surfaces in the container's surface order.
+
+    The SDS API relies on this to map ``extra`` member indices back to the
+    freshly-created surfaces, so the contract is pinned here.
+    """
+    user = UserFactory()
+    surfaces = [
+        SurfaceFactory(created_by=user, name=f"Surface {i}") for i in range(3)
+    ]
+
+    outfile = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    export_container_zip(outfile, surfaces)
+    outfile.close()
+
+    importer = UserFactory()
+    try:
+        with zipfile.ZipFile(outfile.name, mode="r") as zf:
+            imported = import_container_zip(zf, importer)
+    finally:
+        os.remove(outfile.name)
+
+    assert [s.name for s in imported] == [s.name for s in surfaces]

--- a/tests/manager/test_containers.py
+++ b/tests/manager/test_containers.py
@@ -2,12 +2,12 @@
 Tests for writing surface containers
 """
 
+import json
 import os
 import tempfile
 import zipfile
 
 import pytest
-import yaml
 from notifications.models import Notification
 
 import topobank
@@ -52,7 +52,7 @@ def test_surface_container(example_authors):
         surface=surface1, datafile__filename="example4.txt", height_scale_editable=False
     )
     # for topo1b we use a datafile which has an height_scale_factor defined - this is needed in order
-    # to test that this factor is NOT exported to meta.yaml -
+    # to test that this factor is NOT exported to index.json -
     # for the initialisation syntax (datafile__filename) here see:
     # https://factoryboy.readthedocs.io/en/stable/orms.html
 
@@ -85,18 +85,22 @@ def test_surface_container(example_authors):
 
     # reopen and check contents
     with zipfile.ZipFile(outfile.name, mode="r") as zf:
-        meta_file = zf.open("meta.yml")
-        meta = yaml.safe_load(meta_file)
+        # meta.yml is no longer written; index.json is the single source of truth.
+        assert "meta.yml" not in zf.namelist()
+        meta_file = zf.open("index.json")
+        meta = json.load(meta_file)
 
         meta_surfaces = meta["surfaces"]
 
         # check number of surfaces and topographies
         for surf_idx, surf in enumerate(surfaces):
             assert meta_surfaces[surf_idx]["name"] == surf.name
-            assert meta_surfaces[surf_idx]["category"] == surf.category
+            # category is omitted when unset (exclude_none).
+            assert meta_surfaces[surf_idx].get("category") == surf.category
             assert meta_surfaces[surf_idx]["description"] == surf.description
             assert meta_surfaces[surf_idx]["created_by"]["name"] == surf.created_by.name
-            assert meta_surfaces[surf_idx]["created_by"]["orcid"] == surf.created_by.orcid_id
+            # orcid is omitted when the author has none (exclude_none).
+            assert meta_surfaces[surf_idx]["created_by"].get("orcid") == surf.created_by.orcid_id
             assert (
                 len(meta_surfaces[surf_idx]["topographies"])
                 == surf.topography_set.count()

--- a/topobank/manager/container_schema.py
+++ b/topobank/manager/container_schema.py
@@ -138,6 +138,11 @@ class ContainerMeta(BaseModel):
     versions: dict[str, str] = Field(default_factory=dict)
     surfaces: list[SurfaceMeta] = Field(default_factory=list)
     created_at: Optional[str] = None
+    # Opaque, optional metadata that TopoBank carries through verbatim without
+    # interpreting it. It lets plugins (e.g. the SDS API, which owns training
+    # groups) attach extra container-level information; members referenced
+    # therein are expected to be indices into ``surfaces``.
+    extra: Optional[dict] = None
 
     @field_validator("created_at", mode="before")
     @classmethod

--- a/topobank/manager/container_schema.py
+++ b/topobank/manager/container_schema.py
@@ -1,0 +1,146 @@
+"""
+Pydantic schema for the surface-container metadata file.
+
+A surface container is a ZIP archive bundling one or more digital surface twins
+(surfaces), each holding any number of topography measurements, together with
+their data files and a single metadata file.
+
+There is exactly one source of truth for that metadata: ``index.json``. It is
+written by :func:`topobank.manager.export_zip.export_container_zip` and read
+back by :func:`topobank.manager.import_zip.import_container_zip`. Archives
+produced by older versions of TopoBank stored the same structure as a YAML file
+named ``meta.yml``; those are still accepted on import (see
+:func:`topobank.manager.import_zip.load_container_metadata`).
+
+Serialization rule
+-------------------
+``index.json`` is produced with ``model_dump(by_alias=True, exclude_none=True)``:
+any field whose value is ``None`` is omitted entirely. In particular the
+``orcid`` of an author and the ``squeezed-netcdf`` data file are only written
+when present.
+"""
+
+from datetime import date
+from typing import Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+#: Canonical name of the metadata file inside a container archive.
+CONTAINER_METADATA_FILENAME = "index.json"
+#: Name of the legacy YAML metadata file written by older TopoBank versions.
+LEGACY_METADATA_FILENAME = "meta.yml"
+
+# Defaults applied when importing older or partial containers. These mirror the
+# database defaults of the corresponding model fields, so a container that omits
+# an optional attribute imports the same way it would have been created.
+DEFAULT_FILL_UNDEFINED_DATA_MODE = "do-not-fill"
+DEFAULT_DETREND_MODE = "center"
+DEFAULT_MEASUREMENT_DATE = date(1970, 1, 1)
+
+
+class CreatedBy(BaseModel):
+    """Author of a surface or topography."""
+
+    name: str
+    orcid: Optional[str] = None
+
+
+class PropertyMeta(BaseModel):
+    """A single custom key/value property attached to a surface."""
+
+    name: str
+    value: Union[str, int, float]
+    unit: Optional[str] = None
+
+
+class PublicationMeta(BaseModel):
+    """Publication information, present only for published surfaces."""
+
+    url: str
+    license: str
+    authors: str
+    version: int
+    date: str
+    doi_url: str = ""
+    doi_state: str = ""
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def _stringify(cls, value):
+        # YAML may parse an ISO date into a ``datetime``/``date`` object.
+        return value if value is None else str(value)
+
+
+class InstrumentMeta(BaseModel):
+    """Instrument used to acquire a measurement."""
+
+    name: Optional[str] = None
+    type: Optional[str] = None
+    parameters: dict = Field(default_factory=dict)
+
+
+class DatafileMeta(BaseModel):
+    """References to the data files of a single measurement inside the archive."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    #: Original data file as uploaded by the user.
+    original: str
+    #: Optional NetCDF 3 file with preprocessed ("squeezed") data.
+    squeezed_netcdf: Optional[str] = Field(default=None, alias="squeezed-netcdf")
+
+
+class TopographyMeta(BaseModel):
+    """Metadata of a single topography measurement."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    datafile: DatafileMeta
+    size: list[float]
+    # The lateral unit is normally always set, but older archives occasionally
+    # omit it; keep it optional so they still import (as the legacy code did).
+    unit: Optional[str] = None
+    data_source: int = 0
+    has_undefined_data: Optional[bool] = None
+    fill_undefined_data_mode: str = DEFAULT_FILL_UNDEFINED_DATA_MODE
+    detrend_mode: str = DEFAULT_DETREND_MODE
+    is_periodic: bool = False
+    created_by: Optional[CreatedBy] = None
+    # Absent -> default; explicit null is kept (older measurements may lack a
+    # date), matching the previous import behavior.
+    measurement_date: Optional[date] = DEFAULT_MEASUREMENT_DATE
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    instrument: Optional[InstrumentMeta] = None
+    # Only written when the height scale is editable, i.e. not already encoded
+    # in the data file itself (see GH 718).
+    height_scale: Optional[float] = None
+
+
+class SurfaceMeta(BaseModel):
+    """Metadata of a single digital surface twin and its measurements."""
+
+    name: str
+    category: Optional[str] = None
+    created_by: Optional[CreatedBy] = None
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    is_published: bool = False
+    publication: Optional[PublicationMeta] = None
+    properties: Optional[list[PropertyMeta]] = None
+    topographies: list[TopographyMeta] = Field(default_factory=list)
+
+
+class ContainerMeta(BaseModel):
+    """Top-level schema of a container's ``index.json`` (or legacy ``meta.yml``)."""
+
+    versions: dict[str, str] = Field(default_factory=dict)
+    surfaces: list[SurfaceMeta] = Field(default_factory=list)
+    created_at: Optional[str] = None
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _stringify(cls, value):
+        # YAML may parse the timestamp into a ``datetime`` object.
+        return value if value is None else str(value)

--- a/topobank/manager/export_zip.py
+++ b/topobank/manager/export_zip.py
@@ -22,7 +22,7 @@ from .container_schema import CONTAINER_METADATA_FILENAME, ContainerMeta
 _log = logging.getLogger(__name__)
 
 
-def export_container_zip(file, surfaces):
+def export_container_zip(file, surfaces, extra_metadata=None):
     """
     Write container data to a file.
 
@@ -32,6 +32,12 @@ def export_container_zip(file, surfaces):
         Should be opened in "w" mode.
     surfaces: sequence of Surface instances
         Surface which should be included in container.
+    extra_metadata: dict, optional
+        Opaque, optional container-level metadata that is written verbatim to
+        the ``extra`` key of the metadata file. TopoBank does not interpret it;
+        it lets callers (e.g. the SDS API) attach extra information such as
+        training-group membership. Any surface references therein should use
+        indices into ``surfaces``. (Default: None)
 
     Returns
     -------
@@ -134,6 +140,7 @@ def export_container_zip(file, surfaces):
         versions=dict(topobank=topobank.__version__),
         surfaces=surfaces_dicts,
         created_at=str(now()),
+        extra=extra_metadata,
     )
 
     zf.writestr(

--- a/topobank/manager/export_zip.py
+++ b/topobank/manager/export_zip.py
@@ -10,13 +10,14 @@ import textwrap
 import zipfile
 
 import SurfaceTopography
-import yaml
 from django.conf import settings
 from django.utils.text import slugify
 from django.utils.timezone import now
 
 import topobank
 from topobank.supplib.json import ExtendedJSONEncoder
+
+from .container_schema import CONTAINER_METADATA_FILENAME, ContainerMeta
 
 _log = logging.getLogger(__name__)
 
@@ -125,14 +126,24 @@ def export_container_zip(file, surfaces):
     #
     # Add metadata file
     #
-    metadata = dict(
+    # ``index.json`` is the single source of truth for container metadata. We
+    # build it through the pydantic schema, which validates the structure and
+    # normalizes the layout (``exclude_none`` drops absent optional fields such
+    # as an author's ``orcid`` or a missing squeezed data file).
+    metadata = ContainerMeta(
         versions=dict(topobank=topobank.__version__),
         surfaces=surfaces_dicts,
         created_at=str(now()),
     )
 
-    zf.writestr("index.json", json.dumps(metadata, indent=4, cls=ExtendedJSONEncoder))
-    zf.writestr("meta.yml", yaml.dump(metadata))
+    zf.writestr(
+        CONTAINER_METADATA_FILENAME,
+        json.dumps(
+            metadata.model_dump(by_alias=True, exclude_none=True),
+            indent=4,
+            cls=ExtendedJSONEncoder,
+        ),
+    )
 
     #
     # Add a Readme file and license files
@@ -154,8 +165,8 @@ def export_container_zip(file, surfaces):
       missing data points were filled in (if selected).
 
     The metadata for the digital twins and the individual measurements can be
-    found in the auxiliary file 'meta.yml'. It is formatted as
-    [YAML](https://yaml.org/) file.
+    found in the auxiliary file 'index.json'. It is formatted as
+    [JSON](https://www.json.org/) file.
 
     Version information
     ===================

--- a/topobank/manager/import_zip.py
+++ b/topobank/manager/import_zip.py
@@ -1,96 +1,104 @@
-import datetime
-
 import yaml
 from django.core.files import File
 from django.utils.timezone import now
 
 from ..authorization import get_permission_model
 from ..files.models import Manifest
+from .container_schema import (
+    CONTAINER_METADATA_FILENAME,
+    LEGACY_METADATA_FILENAME,
+    ContainerMeta,
+    TopographyMeta,
+)
 from .models import Surface, Topography
 
-TOPOGRAPHY_DEFAULT_ATTR_VALUES = {
-    "tags": [],
-    "fill_undefined_data_mode": Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING,
-    "detrend_mode": "center",
-    "is_periodic": False,
-    "height_scale": 1.0,
-    "data_source": 0,
-    "measurement_date": datetime.date(1970, 1, 1),
-    "description": "",
-}
 
-SURFACE_DEFAULT_ATTR_VALUES = {
-    "tags": [],
-    "description": "",
-    "is_published": False,
-}
-
-
-def import_measurement(topo_dict, topo_file, surface, ignore_missing=False):
+def load_container_metadata(surface_zip, unsafe_yaml_loader=False) -> ContainerMeta:
     """
-    Process a single topography from a surface container ZIP.
+    Load and validate the metadata of a surface container.
+
+    The canonical metadata file is ``index.json``. For backward compatibility
+    with archives produced by older versions of TopoBank, a legacy ``meta.yml``
+    file is accepted as a fallback. In both cases the metadata is validated
+    against (and returned as) a :class:`ContainerMeta` instance.
 
     Parameters
     ----------
-    topo_dict : dict
-        Dictionary with metadata of the topography.
+    surface_zip : zipfile.ZipFile
+        The container archive.
+    unsafe_yaml_loader : bool, optional
+        If True, use an unsafe YAML loader when reading the legacy ``meta.yml``.
+        This can execute malicious code contained in the YAML file and should be
+        used with caution. (Default: False)
+
+    Returns
+    -------
+    ContainerMeta
+        The validated container metadata.
+    """
+    names = set(surface_zip.namelist())
+    if CONTAINER_METADATA_FILENAME in names:
+        with surface_zip.open(CONTAINER_METADATA_FILENAME, mode="r") as f:
+            return ContainerMeta.model_validate_json(f.read())
+    if LEGACY_METADATA_FILENAME in names:
+        with surface_zip.open(LEGACY_METADATA_FILENAME, mode="r") as f:
+            yaml_loader = yaml.full_load if unsafe_yaml_loader else yaml.safe_load
+            return ContainerMeta.model_validate(yaml_loader(f))
+    raise RuntimeError(
+        f"Container archive contains neither '{CONTAINER_METADATA_FILENAME}' nor "
+        f"'{LEGACY_METADATA_FILENAME}'; cannot determine its contents."
+    )
+
+
+def import_measurement(topo_meta: TopographyMeta, topo_file, surface):
+    """
+    Create a single topography from a surface container.
+
+    Parameters
+    ----------
+    topo_meta : TopographyMeta
+        Validated metadata of the topography.
     topo_file : file
         File object with the topography data.
     surface : Surface
         Surface instance to which the topography belongs.
-    ignore_missing : bool, optional
-        If True, try to find reasonable defaults for missing attributes.
-        (Default: False)
     """
-    topo_name = topo_dict["name"]
-
-    size_x, *size_rest = topo_dict["size"]
+    size_x, *size_rest = topo_meta.size
     size_y = None if len(size_rest) == 0 else size_rest[0]
 
     user = surface.created_by
 
-    if ignore_missing:
-        for k, default in TOPOGRAPHY_DEFAULT_ATTR_VALUES.items():
-            topo_dict.setdefault(k, default)
-
     topo_kwargs = dict(
         created_by=user,
-        name=topo_name,
+        name=topo_meta.name,
         surface=surface,
         size_x=size_x,
         size_y=size_y,
-        measurement_date=topo_dict["measurement_date"],
-        description=topo_dict["description"],
-        data_source=topo_dict["data_source"],
-        unit=topo_dict["unit"],
-        tags=topo_dict["tags"],
-        fill_undefined_data_mode=topo_dict["fill_undefined_data_mode"],
-        detrend_mode=topo_dict["detrend_mode"],
-        is_periodic=topo_dict["is_periodic"],
+        measurement_date=topo_meta.measurement_date,
+        description=topo_meta.description,
+        data_source=topo_meta.data_source,
+        unit=topo_meta.unit,
+        tags=topo_meta.tags,
+        fill_undefined_data_mode=topo_meta.fill_undefined_data_mode,
+        detrend_mode=topo_meta.detrend_mode,
+        is_periodic=topo_meta.is_periodic,
     )
 
-    try:
+    if topo_meta.instrument is not None:
         topo_kwargs.update(
-            dict(
-                instrument_name=topo_dict["instrument"]["name"],
-                instrument_type=topo_dict["instrument"]["type"],
-                instrument_parameters=topo_dict["instrument"]["parameters"],
-            )
+            instrument_name=topo_meta.instrument.name or "",
+            instrument_type=topo_meta.instrument.type or "",
+            instrument_parameters=topo_meta.instrument.parameters,
         )
-    except KeyError:
-        # Metadata does not contain instrument information
-        pass
 
-    try:
-        topo_kwargs["height_scale"] = topo_dict["height_scale"]
-    except KeyError:
-        # If height_scale is not included, it will probably already
-        # applied because of file contents while loading
-        pass
+    if topo_meta.height_scale is not None:
+        # If height_scale is not included, it has probably already been applied
+        # because of the file contents while loading.
+        topo_kwargs["height_scale"] = topo_meta.height_scale
 
     topography = Topography(**topo_kwargs)
     topography.datafile = Manifest.objects.create(
-        permissions=surface.permissions, filename=topo_name, created_by=user
+        permissions=surface.permissions, filename=topo_meta.name, created_by=user
     )
     topography.datafile.save_file(File(topo_file))
     # We need to save again to store the new file name
@@ -100,7 +108,6 @@ def import_measurement(topo_dict, topo_file, surface, ignore_missing=False):
 def import_container_zip(
     surface_zip,
     user,
-    datafile_attribute="datafile",
     ignore_missing=False,
     unsafe_yaml_loader=False,
     tag=None,
@@ -110,8 +117,11 @@ def import_container_zip(
 
     This function processes a ZIP archive containing surface data, including metadata and topography files. It creates
     Surface instances for each surface in the archive, sets created_by to the specified user, and imports topographies
-    associated with each surface. It also handles optional tagging of surfaces, setting of default values for missing
-    attributes, and the choice between safe and unsafe YAML loading for metadata.
+    associated with each surface. It also handles optional tagging of surfaces.
+
+    The metadata is loaded and validated through the :class:`ContainerMeta` schema, which preferentially reads the
+    canonical ``index.json`` and falls back to the legacy ``meta.yml``. Missing optional attributes are filled with the
+    schema's defaults, so ``ignore_missing`` is kept only for backward compatibility and no longer changes behavior.
 
     Parameters
     ----------
@@ -119,14 +129,10 @@ def import_container_zip(
         The ZIP archive containing surfaces and their metadata.
     user : topobank.users.models.User
         The user who will be set as created_by of the imported surfaces.
-    datafile_attribute : str, optional
-        The attribute name in the metadata file that stores the file name for a topography's data file.
-        Default is 'datafile'.
     ignore_missing : bool, optional
-        If True, the function will try to find reasonable defaults for missing attributes in the metadata.
-        Default is False.
+        Deprecated and ignored; defaults for missing attributes are now supplied by the schema. Default is False.
     unsafe_yaml_loader : bool, optional
-        If True, an unsafe YAML loader will be used to load the metadata. This can potentially execute
+        If True, an unsafe YAML loader will be used to load a legacy ``meta.yml``. This can potentially execute
         malicious code contained in the YAML file, so it should be used with caution. Default is False.
     tag : str, optional
         An optional tag to add to all imported surfaces. Default is None.
@@ -138,62 +144,50 @@ def import_container_zip(
 
     Notes
     -----
-    The function assumes the ZIP archive's structure and metadata format are correct and does not perform
-    extensive validation of the archive's contents.
+    The function assumes the ZIP archive's structure is correct and does not perform extensive validation of the
+    archive's contents beyond the metadata schema.
     """
+    meta = load_container_metadata(surface_zip, unsafe_yaml_loader=unsafe_yaml_loader)
+
     surfaces = []
-    with surface_zip.open("meta.yml", mode="r") as meta_file:
-        yaml_loader = yaml.full_load if unsafe_yaml_loader else yaml.safe_load
-        meta = yaml_loader(meta_file)
+    import_time = str(now())
 
-        for surface_dict in meta["surfaces"]:
-            if ignore_missing:
-                for k, default in SURFACE_DEFAULT_ATTR_VALUES.items():
-                    surface_dict.setdefault(k, default)
+    for surface_meta in meta.surfaces:
+        surface_description = surface_meta.description
+        surface_description += (
+            f'\n\nImported from file "{surface_zip.filename}" on {import_time}.'
+        )
+        tags = set(surface_meta.tags)
+        if tag is not None:
+            tags.add(tag)
+        surface = Surface.objects.create(
+            created_by=user,
+            name=surface_meta.name,
+            category=surface_meta.category,
+            description=surface_description,
+            tags=tags,
+            permissions=get_permission_model().objects.create(),
+        )
+        surface.save()
+        surface.permissions.grant_for_user(user, "full")
 
-            import_time = str(now())
+        if surface_meta.properties:
+            from topobank.properties.models import Property
 
-            surface_description = surface_dict["description"]
-            surface_description += (
-                f'\n\nImported from file "{surface_zip.filename}" on {import_time}.'
-            )
-            tags = set(surface_dict["tags"])
-            if tag is not None:
-                tags.add(tag)
-            surface = Surface.objects.create(
-                created_by=user,
-                name=surface_dict["name"],
-                category=surface_dict["category"],
-                description=surface_description,
-                tags=tags,
-                permissions=get_permission_model().objects.create(),
-            )
-            surface.save()
-            surface.permissions.grant_for_user(user, "full")
-
-            # WARNING: Does this need to be updated to new property API??
-            if "properties" in surface_dict:
-                from topobank.properties.models import Property
-
-                for property_dict in surface_dict["properties"]:
-                    name = property_dict["name"]
-                    value = property_dict["value"]
-                    unit = property_dict.get("unit", None)
-                    Property.objects.create(
-                        surface=surface, name=name, value=value, unit=unit
-                    )
-                surface.save()
-
-            surfaces += [surface]
-
-            for topo_idx, topo_dict in enumerate(surface_dict["topographies"]):
-                datafile_name = topo_dict[datafile_attribute][
-                    "original"
-                ]  # we just import the original
-                topo_file = surface_zip.open(datafile_name, mode="r")
-
-                import_measurement(
-                    topo_dict, topo_file, surface, ignore_missing=ignore_missing
+            for property_meta in surface_meta.properties:
+                Property.objects.create(
+                    surface=surface,
+                    name=property_meta.name,
+                    value=property_meta.value,
+                    unit=property_meta.unit,
                 )
+            surface.save()
+
+        surfaces.append(surface)
+
+        for topo_meta in surface_meta.topographies:
+            # We just import the original data file.
+            topo_file = surface_zip.open(topo_meta.datafile.original, mode="r")
+            import_measurement(topo_meta, topo_file, surface)
 
     return surfaces

--- a/topobank/manager/management/commands/import_datasets.py
+++ b/topobank/manager/management/commands/import_datasets.py
@@ -4,38 +4,20 @@ Management command for importing a surface from file(s).
 ONLY USE FROM TRUSTED SOURCES!
 """
 
-import datetime
 import logging
 import zipfile
 
-import yaml
 from django.contrib.auth import get_user_model as _get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.timezone import now
 
+from topobank.manager.import_zip import load_container_metadata
 from topobank.manager.models import Surface, Topography
 from topobank.properties.models import Property
 
 User = _get_user_model()
 
 _log = logging.getLogger(__name__)
-
-TOPOGRAPHY_DEFAULT_ATTR_VALUES = {
-    "tags": [],
-    "fill_undefined_data_mode": Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING,
-    "detrend_mode": "center",
-    "is_periodic": False,
-    "height_scale": 1.0,
-    "data_source": 0,
-    "measurement_date": datetime.date(1970, 1, 1),
-    "description": "",
-}
-
-SURFACE_DEFAULT_ATTR_VALUES = {
-    "tags": [],
-    "description": "",
-    "is_published": False,
-}
 
 
 class Command(BaseCommand):
@@ -76,44 +58,33 @@ class Command(BaseCommand):
             "--unsafe-yaml-loader",
             action="store_true",
             dest="unsafe_yaml_loader",
-            help="Use unsafe YAML loader - use with care, this is potentially dangerous, "
-            "malicious code execution is possible.",
-        )
-
-        parser.add_argument(
-            "--name-as-datafile",
-            action="store_true",
-            dest="name_as_datafile",
-            help='Use the "name" attribute of topographies instead of "datafile". Useful for old container format.',
+            help="Use unsafe YAML loader when reading a legacy 'meta.yml' - use with care, "
+            "this is potentially dangerous, malicious code execution is possible.",
         )
 
         parser.add_argument(
             "--ignore-missing",
             action="store_true",
             dest="ignore_missing",
-            help="If attributes are missing, try to use feasible defaults . Useful for old container format.",
+            help="Deprecated and ignored: defaults for missing attributes are now "
+            "supplied by the container metadata schema.",
         )
 
-    def process_topography(
-        self, topo_dict, topo_file, surface, ignore_missing=False, dry_run=False
-    ):
-        self.stdout.write(
-            self.style.NOTICE(f"  Topography name: '{topo_dict['name']}'")
-        )
-        self.stdout.write(
-            self.style.NOTICE(f"  Original creator is '{topo_dict['created_by']}'.")
-        )
+    def process_topography(self, topo_meta, topo_file, surface, dry_run=False):
+        self.stdout.write(self.style.NOTICE(f"  Topography name: '{topo_meta.name}'"))
+        if topo_meta.created_by is not None:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"  Original creator is '{topo_meta.created_by.name}'."
+                )
+            )
 
-        topo_name = topo_dict["name"]
+        topo_name = topo_meta.name
 
-        size_x, *size_rest = topo_dict["size"]
+        size_x, *size_rest = topo_meta.size
         size_y = None if len(size_rest) == 0 else size_rest[0]
 
         user = surface.created_by
-
-        if ignore_missing:
-            for k, default in TOPOGRAPHY_DEFAULT_ATTR_VALUES.items():
-                topo_dict.setdefault(k, default)
 
         topo_kwargs = dict(
             created_by=user,
@@ -121,34 +92,27 @@ class Command(BaseCommand):
             surface=surface,
             size_x=size_x,
             size_y=size_y,
-            measurement_date=topo_dict["measurement_date"],
-            description=topo_dict["description"],
-            data_source=topo_dict["data_source"],
-            unit=topo_dict["unit"],
-            tags=topo_dict["tags"],
-            fill_undefined_data_mode=topo_dict["fill_undefined_data_mode"],
-            detrend_mode=topo_dict["detrend_mode"],
-            is_periodic=topo_dict["is_periodic"],
+            measurement_date=topo_meta.measurement_date,
+            description=topo_meta.description,
+            data_source=topo_meta.data_source,
+            unit=topo_meta.unit,
+            tags=topo_meta.tags,
+            fill_undefined_data_mode=topo_meta.fill_undefined_data_mode,
+            detrend_mode=topo_meta.detrend_mode,
+            is_periodic=topo_meta.is_periodic,
         )
 
-        try:
+        if topo_meta.instrument is not None:
             topo_kwargs.update(
-                dict(
-                    instrument_name=topo_dict["instrument"]["name"],
-                    instrument_type=topo_dict["instrument"]["type"],
-                    instrument_parameters=topo_dict["instrument"]["parameters"],
-                )
+                instrument_name=topo_meta.instrument.name or "",
+                instrument_type=topo_meta.instrument.type or "",
+                instrument_parameters=topo_meta.instrument.parameters,
             )
-        except KeyError:
-            # Metadata does not contain instrument information
-            pass
 
-        try:
-            topo_kwargs["height_scale"] = topo_dict["height_scale"]
-        except KeyError:
-            # If height_scale is not included, it will probably already
-            # applied because of file contents while loading
-            pass
+        if topo_meta.height_scale is not None:
+            # If height_scale is not included, it has probably already been
+            # applied because of the file contents while loading.
+            topo_kwargs["height_scale"] = topo_meta.height_scale
 
         # Constructing the instance validates the metadata. On a dry run we stop
         # here: nothing is persisted (the surface is not saved either, so saving
@@ -168,8 +132,6 @@ class Command(BaseCommand):
         self,
         surface_zip,
         user,
-        datafile_attribute="datafile",
-        ignore_missing=False,
         dry_run=False,
         unsafe_yaml_loader=False,
     ):
@@ -181,102 +143,89 @@ class Command(BaseCommand):
             archive with surfaces
         user: topobank.users.User
             User which should be creator of the surface and all data.
-        datafile_attribute: str
-            attribute in file from which the file name for a topography is stored
-        ignore_missing: bool
-            If True, try to find reasonable defaults for missing attributes.
         dry_run: bool
             If True, only show what would be done without actually importing data.
         unsafe_yaml_loader: bool
-            If True, use an unsafe YAML loader. Use this with care,
+            If True, use an unsafe YAML loader for a legacy 'meta.yml'. Use this with care,
             if there is malicious code in the metadata, this can compromise your system.
         """
-        with surface_zip.open("meta.yml", mode="r") as meta_file:
+        meta = load_container_metadata(
+            surface_zip, unsafe_yaml_loader=unsafe_yaml_loader
+        )
 
-            yaml_loader = yaml.full_load if unsafe_yaml_loader else yaml.safe_load
-            meta = yaml_loader(meta_file)
+        for surface_meta in meta.surfaces:
+            import_time = str(now())
 
-            for surface_dict in meta["surfaces"]:
-
-                if ignore_missing:
-                    for k, default in SURFACE_DEFAULT_ATTR_VALUES.items():
-                        surface_dict.setdefault(k, default)
-
-                import_time = str(now())
-
-                surface_description = surface_dict["description"]
-                surface_description += (
-                    f'\n\nImported from file "{surface_zip.filename}" on {import_time}.'
+            surface_description = surface_meta.description
+            surface_description += (
+                f'\n\nImported from file "{surface_zip.filename}" on {import_time}.'
+            )
+            surface = Surface(
+                created_by=user,
+                name=surface_meta.name,
+                category=surface_meta.category,
+                description=surface_description,
+                tags=surface_meta.tags,
+            )
+            if not dry_run:
+                surface.save()
+                self.stdout.write(
+                    self.style.SUCCESS(f"Surface '{surface.name}' saved.")
                 )
-                surface = Surface(
-                    created_by=user,
-                    name=surface_dict["name"],
-                    category=surface_dict["category"],
-                    description=surface_description,
-                    tags=surface_dict["tags"],
-                )
-                if not dry_run:
-                    surface.save()
-                    self.stdout.write(
-                        self.style.SUCCESS(f"Surface '{surface.name}' saved.")
+
+            num_topographies = len(surface_meta.topographies)
+            for topo_idx, topo_meta in enumerate(surface_meta.topographies):
+                self.stdout.write(
+                    self.style.NOTICE(
+                        f"Processing topography {topo_idx + 1}/{num_topographies} in archive..."
                     )
-
-                num_topographies = len(surface_dict["topographies"])
-                for topo_idx, topo_dict in enumerate(surface_dict["topographies"]):
+                )
+                datafile_name = topo_meta.datafile.original
+                try:
                     self.stdout.write(
                         self.style.NOTICE(
-                            f"Processing topography {topo_idx + 1}/{num_topographies} in archive..."
+                            f"  Trying to read file '{datafile_name}' in archive..."
                         )
                     )
-                    try:
-                        datafile_name = topo_dict[datafile_attribute][
-                            "original"
-                        ]  # there will be more entries later
-                        self.stdout.write(
-                            self.style.NOTICE(
-                                f"  Trying to read file '{datafile_name}' in archive..."
-                            )
+                    topo_file = surface_zip.open(datafile_name, mode="r")
+                    self.stdout.write(
+                        self.style.NOTICE(
+                            f"  Datafile '{datafile_name}' found in archive."
                         )
-                        topo_file = surface_zip.open(datafile_name, mode="r")
-                        self.stdout.write(
-                            self.style.NOTICE(
-                                f"  Datafile '{datafile_name}' found in archive."
-                            )
-                        )
-                    except Exception as exc:
-                        raise CommandError(
-                            f"  Cannot load datafile for '{topo_dict}' from archive. Reason: {exc}"
-                        ) from exc
-                    try:
-                        self.process_topography(
-                            topo_dict,
-                            topo_file,
-                            surface,
-                            ignore_missing=ignore_missing,
-                            dry_run=dry_run,
-                        )
-                    except Exception as exc:
-                        raise CommandError(
-                            f"  Cannot create topography from description {topo_dict}. Reason: {exc}"
-                        ) from exc
+                    )
+                except Exception as exc:
+                    raise CommandError(
+                        f"  Cannot load datafile '{datafile_name}' from archive. Reason: {exc}"
+                    ) from exc
+                try:
+                    self.process_topography(
+                        topo_meta,
+                        topo_file,
+                        surface,
+                        dry_run=dry_run,
+                    )
+                except Exception as exc:
+                    raise CommandError(
+                        f"  Cannot create topography '{topo_meta.name}'. Reason: {exc}"
+                    ) from exc
 
-                if "properties" in surface_dict and not dry_run:
-                    num_properties = len(surface_dict["properties"])
-                    for prop_idx, prop_dict in enumerate(surface_dict["properties"]):
-                        self.stdout.write(
-                            self.style.NOTICE(
-                                f"Processing property {prop_idx + 1}/{num_properties} in archive..."
-                            )
+            if surface_meta.properties and not dry_run:
+                num_properties = len(surface_meta.properties)
+                for prop_idx, prop_meta in enumerate(surface_meta.properties):
+                    self.stdout.write(
+                        self.style.NOTICE(
+                            f"Processing property {prop_idx + 1}/{num_properties} in archive..."
                         )
-                        unit = prop_dict.get("unit", None)
-                        Property.objects.create(
-                            surface=surface,
-                            permissions=surface.permissions,
-                            name=prop_dict["name"],
-                            value_categorical=prop_dict["value"] if unit is None else None,
-                            value_numerical=None if unit is None else prop_dict["value"],
-                            unit=unit,
-                        )
+                    )
+                    unit = prop_meta.unit
+                    Property.objects.create(
+                        surface=surface,
+                        permissions=surface.permissions,
+                        name=prop_meta.name,
+                        value_categorical=prop_meta.value if unit is None else None,
+                        value_numerical=None if unit is None else prop_meta.value,
+                        unit=unit,
+                    )
 
     def handle(self, *args, **options):
         """
@@ -314,15 +263,8 @@ class Command(BaseCommand):
                 self.style.WARNING("You are using an unsafe YAML loader.")
             )
 
-        datafile_attribute = "name" if options["name_as_datafile"] else "datafile"
-        self.stdout.write(
-            self.style.NOTICE(
-                f"As datafile attribute '{datafile_attribute}' will be used."
-            )
-        )
-
         #
-        # Then process the given IP archives with surfaces
+        # Then process the given archives with surfaces
         #
         for filename in options["surface_archives"]:
             try:
@@ -330,9 +272,7 @@ class Command(BaseCommand):
                     self.process_dataset_archive(
                         surface_zip,
                         user,
-                        datafile_attribute,
-                        ignore_missing=options["ignore_missing"],
-                        dry_run=options["dry_run"],
+                        dry_run=dry_run,
                         unsafe_yaml_loader=unsafe_yaml_loader,
                     )
             except Exception as exc:
@@ -340,7 +280,7 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.ERROR(err_msg))
                 raise CommandError(err_msg) from exc
 
-        if options["dry_run"]:
+        if dry_run:
             self.stdout.write(
                 self.style.WARNING("This was a dry run, nothing has been changed.")
             )


### PR DESCRIPTION
This PR:
* Implements a pydantic schema for the metadata file
* Drops the YAML files
* Adds the option to attach arbitrary metadata