### PR TITLE
Optionally remap logical Celery queue names at publish time

### DIFF
--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -432,10 +432,14 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         impl = self.implementation
         if hasattr(impl.Meta, "celery_queue") and impl.Meta.celery_queue is not None:
             # Implementation-specific queue
-            return impl.Meta.celery_queue
+            queue = impl.Meta.celery_queue
         else:
             # Default queue for workflow result tasks
-            return settings.TOPOBANK_ANALYSIS_QUEUE
+            queue = settings.TOPOBANK_ANALYSIS_QUEUE
+        # Implementations may emit bare logical queue names (e.g. "analysis");
+        # translate them to the configured queue so the task routes to a
+        # predefined queue. Unknown/already-configured names pass through.
+        return getattr(settings, "CELERY_LOGICAL_QUEUE_MAP", {}).get(queue, queue)
 
     # FIXME: discuss whether to remove this method and use the generic one from PermissionMixin
     # overrides PermissionMixin.authorize_user <- this one returns nothing, raises exception on failure


### PR DESCRIPTION
## Summary

`WorkflowResult.get_celery_queue()` returns a *logical* queue name — either an implementation's `Meta.celery_queue` or the `TOPOBANK_ANALYSIS_QUEUE` default — and that name is passed straight to `apply_async(queue=...)`.

This breaks on brokers where the actual queue names differ from those logical names. In particular, Celery's SQS transport with `predefined_queues` rejects publishing to a queue whose name is not a key in `predefined_queues`:

```
kombu.transport.SQS.UndefinedQueueException:
    Queue with name 'analysis' must be defined in 'predefined_queues'.
```

A common deployment pattern is to prefix queue names per environment (e.g. `myenv-analysis`) while implementations still emit the bare logical name (`analysis`), which makes every task submission 500 on publish.

## Change

Add an optional `CELERY_LOGICAL_QUEUE_MAP` setting that maps logical queue names to the configured broker queue names. `get_celery_queue()` applies it as the final step:

```python
return getattr(settings, "CELERY_LOGICAL_QUEUE_MAP", {}).get(queue, queue)
```

- **Opt-in and backward compatible**: when the setting is unset it defaults to `{}`, so the queue name is returned unchanged and existing deployments are unaffected.
- Names not present in the map (including already-configured names) pass through untouched, so the mapping is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)