### PR TITLE
MAINT: Plumb force submit through task submission

### DIFF
--- a/tests/analysis/test_models.py
+++ b/tests/analysis/test_models.py
@@ -226,3 +226,23 @@ def test_submit_again(test_workflow):
     analysis = TopographyAnalysisFactory()
     new_analysis = analysis.submit_again()
     assert new_analysis.task_state == WorkflowResult.PENDING
+
+
+@pytest.mark.django_db
+def test_submit_dispatch_carries_callers_force_flag(
+    test_workflow, mocker, django_capture_on_commit_callbacks
+):
+    topo = Topography1DFactory()
+    user = topo.created_by
+    dispatch = mocker.patch(
+        "topobank.analysis.models.submit_analysis_task_to_celery"
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        analysis = test_workflow.submit(user, topo)
+    dispatch.assert_called_once_with(analysis, False)
+
+    dispatch.reset_mock()
+    with django_capture_on_commit_callbacks(execute=True):
+        forced = test_workflow.submit(user, topo, force_submit=True)
+    dispatch.assert_called_once_with(forced, True)

--- a/tests/analysis/test_surface_set_workflows.py
+++ b/tests/analysis/test_surface_set_workflows.py
@@ -198,6 +198,27 @@ def test_submit_for_surfaces_dedups_and_force_resubmits(
 
 
 @pytest.mark.django_db
+def test_submit_for_surfaces_dispatch_carries_callers_force_flag(
+    test_workflow, user_alice, mocker, django_capture_on_commit_callbacks
+):
+    s1 = SurfaceFactory(created_by=user_alice)
+    dispatch = mocker.patch(
+        "topobank.analysis.models.submit_analysis_task_to_celery"
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        analysis = test_workflow.submit_for_surfaces(user=user_alice, surfaces=[s1])
+    dispatch.assert_called_once_with(analysis, False)
+
+    dispatch.reset_mock()
+    with django_capture_on_commit_callbacks(execute=True):
+        forced = test_workflow.submit_for_surfaces(
+            user=user_alice, surfaces=[s1], force_submit=True
+        )
+    dispatch.assert_called_once_with(forced, True)
+
+
+@pytest.mark.django_db
 def test_submit_for_surfaces_uses_explicit_owned_by_id(
     test_workflow, user_alice
 ):

--- a/tests/analysis/test_tasks.py
+++ b/tests/analysis/test_tasks.py
@@ -131,6 +131,95 @@ def test_prepare_dependency_tasks_schedules_new_dependencies(two_topos, test_wor
 
 
 @pytest.mark.django_db
+def test_prepare_dependency_tasks_reuses_successful_dependencies(
+    two_topos, test_workflow
+):
+    topo = Topography.objects.first()
+    old_parent = _pending_analysis(topo, "topobank.testing.test2")
+    dependencies = old_parent.function.get_dependencies(old_parent)
+    _, scheduled = prepare_dependency_tasks(
+        dependencies, force=False, user=old_parent.created_by, parent=old_parent
+    )
+    WorkflowResult.objects.filter(pk__in=[d.pk for d in scheduled.values()]).update(
+        task_state=WorkflowResult.SUCCESS
+    )
+
+    new_parent = _pending_analysis(topo, "topobank.testing.test2")
+    finished, rescheduled = prepare_dependency_tasks(
+        new_parent.function.get_dependencies(new_parent),
+        force=False,
+        user=new_parent.created_by,
+        parent=new_parent,
+    )
+
+    assert len(rescheduled) == 0
+    assert len(finished) == 2
+    for dep in finished.values():
+        # A reused result keeps the attribution of the run that computed it.
+        assert dep.metadata["parent_workflow_result_id"] == old_parent.id
+
+
+@pytest.mark.django_db
+def test_prepare_dependency_tasks_retries_failed_and_restamps_parent(
+    two_topos, test_workflow
+):
+    topo = Topography.objects.first()
+    old_parent = _pending_analysis(topo, "topobank.testing.test2")
+    dependencies = old_parent.function.get_dependencies(old_parent)
+    _, scheduled = prepare_dependency_tasks(
+        dependencies, force=False, user=old_parent.created_by, parent=old_parent
+    )
+    WorkflowResult.objects.filter(pk__in=[d.pk for d in scheduled.values()]).update(
+        task_state=WorkflowResult.FAILURE
+    )
+
+    new_parent = _pending_analysis(topo, "topobank.testing.test2")
+    finished, rescheduled = prepare_dependency_tasks(
+        new_parent.function.get_dependencies(new_parent),
+        force=False,
+        user=new_parent.created_by,
+        parent=new_parent,
+    )
+
+    # Failed dependencies are retried even without force, and their parent
+    # attribution follows the run that triggers the retry.
+    assert len(finished) == 0
+    assert len(rescheduled) == 2
+    for dep in rescheduled.values():
+        dep.refresh_from_db()
+        assert dep.metadata["parent_workflow_result_id"] == new_parent.id
+
+
+@pytest.mark.django_db
+def test_prepare_dependency_tasks_force_recomputes_and_restamps_parent(
+    two_topos, test_workflow
+):
+    topo = Topography.objects.first()
+    old_parent = _pending_analysis(topo, "topobank.testing.test2")
+    dependencies = old_parent.function.get_dependencies(old_parent)
+    _, scheduled = prepare_dependency_tasks(
+        dependencies, force=False, user=old_parent.created_by, parent=old_parent
+    )
+    WorkflowResult.objects.filter(pk__in=[d.pk for d in scheduled.values()]).update(
+        task_state=WorkflowResult.SUCCESS
+    )
+
+    new_parent = _pending_analysis(topo, "topobank.testing.test2")
+    finished, rescheduled = prepare_dependency_tasks(
+        new_parent.function.get_dependencies(new_parent),
+        force=True,
+        user=new_parent.created_by,
+        parent=new_parent,
+    )
+
+    assert len(finished) == 0
+    assert len(rescheduled) == 2
+    for dep in rescheduled.values():
+        dep.refresh_from_db()
+        assert dep.metadata["parent_workflow_result_id"] == new_parent.id
+
+
+@pytest.mark.django_db
 def test_schedule_workflow_runs_dependencies_end_to_end(two_topos, test_workflow):
     topo = Topography.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test2")

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -610,7 +610,6 @@ def submit_analysis_task_to_celery(analysis: WorkflowResult, force_submit: bool)
     """
     from .tasks import schedule_workflow
 
-    # TODO: force_submit is currently hardcoded to True everywhere this is called.
     _log.debug(f"Submitting task for WorkflowResult {analysis.id}...")
     analysis.task_id = schedule_workflow.apply_async(
         args=[analysis.id, force_submit], queue=analysis.get_celery_queue()
@@ -831,7 +830,9 @@ class Workflow:
             # analyses no longer have subjects)
             existing_analyses.filter(name__isnull=True).delete()
 
-            return self._submit_new_analysis(user, subject, kwargs)
+            return self._submit_new_analysis(
+                user, subject, kwargs, force_submit=force_submit
+            )
         else:
             # There seem to be viable analyses. Fetch the latest one.
             analysis = existing_analyses.order_by("task_start_time").last()
@@ -842,6 +843,7 @@ class Workflow:
         user: settings.AUTH_USER_MODEL,
         subject: Union[Tag, Topography, Surface],
         kwargs: dict,
+        force_submit: bool = False,
     ):
         """
         Create and submit a new WorkflowResult analysis.
@@ -854,6 +856,9 @@ class Workflow:
             Instance which will be subject of the WorkflowResult.
         kwargs: dict
             Keyword arguments for the function which should be saved to database.
+        force_submit: bool, optional
+            Recompute dependencies even if they already completed successfully.
+            (Default: False)
 
         Returns
         -------
@@ -885,7 +890,7 @@ class Workflow:
             analysis.set_pending_state()
             analysis.permissions.grant_for_user(user, "edit")
             transaction.on_commit(
-                partial(submit_analysis_task_to_celery, analysis, True)
+                partial(submit_analysis_task_to_celery, analysis, force_submit)
             )
         return analysis
 
@@ -941,7 +946,12 @@ class Workflow:
         if force_submit or successful_or_running.count() == 0:
             existing.filter(name__isnull=True).delete()
             return self._submit_new_analysis_for_surfaces(
-                user, surfaces, surface_set, kwargs, owned_by_id=owned_by_id
+                user,
+                surfaces,
+                surface_set,
+                kwargs,
+                owned_by_id=owned_by_id,
+                force_submit=force_submit,
             )
         else:
             return existing.order_by("task_start_time").last()
@@ -953,6 +963,7 @@ class Workflow:
         surface_set,
         kwargs: dict,
         owned_by_id=None,
+        force_submit: bool = False,
     ):
         """Create and submit a new WorkflowResult for a surface set."""
         _log.info(
@@ -980,7 +991,7 @@ class Workflow:
             analysis.set_pending_state()
             analysis.permissions.grant_for_user(user, "edit")
             transaction.on_commit(
-                partial(submit_analysis_task_to_celery, analysis, True)
+                partial(submit_analysis_task_to_celery, analysis, force_submit)
             )
         return analysis
 

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -528,16 +528,30 @@ def prepare_dependency_tasks(dependencies: Dict[Any, WorkflowDefinition], force:
             scheduled_dependent_analyses[key] = new_analysis
         else:
             # An analysis exists. Check whether it is successful or failed.
-            # task_state is the *self reported* state, not the Celery state
-            if not force and existing_analysis.task_state in [
-                WorkflowResult.FAILURE,
-                WorkflowResult.SUCCESS,
-            ]:
+            # task_state is the *self reported* state, not the Celery state.
+            # Successful results are reused unless `force` asks for a
+            # recompute; failed ones are always retried, since the failure may
+            # stem from a transient error or a since-fixed bug.
+            if not force and existing_analysis.task_state == WorkflowResult.SUCCESS:
                 # This one does not need to be scheduled
                 finished_dependent_analyses[key] = existing_analysis
             else:
-                # We schedule everything else, possibly again. `perform_analysis` will
-                # automatically terminate if an analysis already completed successfully.
+                # We schedule everything else, possibly again. Point the
+                # dependency at the parent that is re-running it, so task
+                # events are attributed to the triggering run instead of
+                # whichever parent originally created the row.
+                if (
+                    parent is not None
+                    and (existing_analysis.metadata or {}).get(
+                        "parent_workflow_result_id"
+                    )
+                    != parent.id
+                ):
+                    existing_analysis.metadata = {
+                        **(existing_analysis.metadata or {}),
+                        "parent_workflow_result_id": parent.id,
+                    }
+                    existing_analysis.save(update_fields=["metadata"])
                 scheduled_dependent_analyses[key] = existing_analysis
 
     return (


### PR DESCRIPTION
## Summary

- Thread `force_submit` through `Workflow._submit_new_analysis` and `_submit_new_analysis_for_surfaces` instead of hardcoding `True` when submitting the Celery task, so a normal submission no longer forces recomputation of dependencies.
- In `prepare_dependency_tasks`, only reuse dependency results in the `SUCCESS` state; failed dependencies are always rescheduled since the failure may be transient or since-fixed.
- When re-running an existing dependency, re-stamp its `metadata["parent_workflow_result_id"]` to the parent that triggered the re-run, so task events are attributed to the triggering run rather than whichever parent originally created the row.

## Test plan

- New tests in `tests/analysis/test_tasks.py` covering dependency reuse/rescheduling and parent re-stamping
- New tests in `tests/analysis/test_models.py` and `tests/analysis/test_surface_set_workflows.py` covering `force_submit` propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)