### PR TITLE
MAINT: Carry dependency parent attribution on the Celery task

### DIFF
--- a/tests/analysis/test_tasks.py
+++ b/tests/analysis/test_tasks.py
@@ -7,6 +7,8 @@ synchronously) executes the whole pipeline in-process, including dependency
 resolution via chords.
 """
 
+from contextlib import contextmanager
+
 import pytest
 
 # Registers the test workflow implementations ("topobank.testing.test",
@@ -145,3 +147,78 @@ def test_schedule_workflow_runs_dependencies_end_to_end(two_topos, test_workflow
     deps = WorkflowResult.objects.filter(workflow_name="topobank.testing.test")
     assert deps.count() >= 2
     assert all(d.task_state == WorkflowResult.SUCCESS for d in deps)
+
+
+# ---------------------------------------------------------------------------
+# Parent attribution: the dispatching parent travels with the Celery task
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _capture_execute_workflow_dispatches():
+    """Record (args, kwargs) of every execute_workflow run via task_prerun —
+    the same signal downstream SSE bridges read attribution from."""
+    from celery.signals import task_prerun
+
+    captured = []
+
+    def _capture(sender=None, args=None, kwargs=None, **extra):
+        if getattr(sender, "name", None) == execute_workflow.name:
+            captured.append((tuple(args or ()), dict(kwargs or {})))
+
+    task_prerun.connect(_capture, weak=False)
+    try:
+        yield captured
+    finally:
+        task_prerun.disconnect(_capture)
+
+
+@pytest.mark.django_db
+def test_dependency_dispatch_carries_parent_id(two_topos, test_workflow):
+    topo = Topography.objects.first()
+    analysis = _pending_analysis(topo, "topobank.testing.test2")
+
+    with _capture_execute_workflow_dispatches() as captured:
+        perform_analysis.apply(args=(analysis.id, True))
+
+    dep_ids = set(
+        WorkflowResult.objects.filter(
+            workflow_name="topobank.testing.test"
+        ).values_list("id", flat=True)
+    )
+    dep_runs = [(a, kw) for a, kw in captured if a[0] in dep_ids]
+    parent_runs = [(a, kw) for a, kw in captured if a[0] == analysis.id]
+
+    assert len(dep_runs) == 2
+    for args_, kwargs_ in dep_runs:
+        assert args_[1] is True  # executed as a dependency
+        assert kwargs_["parent_id"] == analysis.id
+
+    # The top-level run itself carries no parent, so it can never be
+    # misclassified as someone's dependency.
+    assert len(parent_runs) == 1
+    assert parent_runs[0][1].get("parent_id") is None
+
+
+@pytest.mark.django_db
+def test_rerun_by_second_parent_attributes_to_that_parent(two_topos, test_workflow):
+    """A second parent force-re-running shared dependency rows carries its own
+    id in the task kwargs, while the rows keep the creation-time stamp of the
+    parent that created them — per-execution attribution does not depend on
+    (or mutate) the shared row."""
+    topo = Topography.objects.first()
+    parent_a = _pending_analysis(topo, "topobank.testing.test2")
+    perform_analysis.apply(args=(parent_a.id, True))
+
+    parent_b = _pending_analysis(topo, "topobank.testing.test2")
+    with _capture_execute_workflow_dispatches() as captured:
+        perform_analysis.apply(args=(parent_b.id, True))
+
+    dep_rows = WorkflowResult.objects.filter(workflow_name="topobank.testing.test")
+    dep_ids = set(dep_rows.values_list("id", flat=True))
+    dep_runs = [(a, kw) for a, kw in captured if a[0] in dep_ids]
+
+    assert len(dep_runs) == 2
+    assert all(kw["parent_id"] == parent_b.id for _, kw in dep_runs)
+    for dep in dep_rows:
+        assert dep.metadata["parent_workflow_result_id"] == parent_a.id

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -60,7 +60,8 @@ def get_current_configuration():
 
 
 @app.task(bind=True, soft_time_limit=3600, time_limit=3700)
-def schedule_workflow(self: celery.Task, analysis_id: int, force: bool, is_dependency: bool = False):
+def schedule_workflow(self: celery.Task, analysis_id: int, force: bool,
+                      is_dependency: bool = False, parent_id: int = None):
     """Schedule a workflow, checking and setting up dependencies first.
 
     This task handles the dependency resolution phase:
@@ -77,6 +78,15 @@ def schedule_workflow(self: celery.Task, analysis_id: int, force: bool, is_depen
         ID of `topobank.analysis.WorkflowResult` instance.
     force : bool
         Submission was forced, which means we need to renew dependencies.
+    is_dependency : bool, optional
+        Whether this workflow was scheduled as a dependency of another
+        workflow. (Default: False)
+    parent_id : int, optional
+        ID of the WorkflowResult whose scheduling triggered this run, when
+        this workflow runs as a dependency. Attribution travels with the
+        Celery task rather than the (shared) WorkflowResult row, so
+        concurrent parents re-running the same dependency each carry their
+        own id. (Default: None)
     """
     from .models import WorkflowResult
 
@@ -154,10 +164,14 @@ def schedule_workflow(self: celery.Task, analysis_id: int, force: bool, is_depen
             # Create chord: run all dependencies, then execute this workflow
             task = celery.chord(
                 (
-                    schedule_workflow.si(dep.id, False, is_dependency=True).set(queue=celery_queue)
+                    schedule_workflow.si(
+                        dep.id, False, is_dependency=True, parent_id=analysis.id
+                    ).set(queue=celery_queue)
                     for dep in scheduled_dependencies.values()
                 ),
-                execute_workflow.si(analysis.id, is_dependency=is_dependency).set(queue=celery_queue),
+                execute_workflow.si(
+                    analysis.id, is_dependency=is_dependency, parent_id=parent_id
+                ).set(queue=celery_queue),
             ).apply_async()
 
             # Store chord task id
@@ -193,11 +207,14 @@ def schedule_workflow(self: celery.Task, analysis_id: int, force: bool, is_depen
     # Using .apply_async() here would cause a race condition: the chord would see
     # schedule_workflow as "complete" while execute_workflow is still running.
     _log.debug(f"{analysis_id}/{self.request.id}: Calling execute_workflow directly.")
-    execute_workflow.apply(args=(analysis.id, is_dependency))
+    execute_workflow.apply(
+        args=(analysis.id, is_dependency), kwargs={"parent_id": parent_id}
+    )
 
 
 @app.task(bind=True, soft_time_limit=3600, time_limit=3700)
-def execute_workflow(self: celery.Task, analysis_id: int, is_dependency: bool = False):
+def execute_workflow(self: celery.Task, analysis_id: int,
+                     is_dependency: bool = False, parent_id: int = None):
     """Execute the actual workflow after dependencies are resolved.
 
     This task assumes all dependencies are already complete and handles:
@@ -211,6 +228,12 @@ def execute_workflow(self: celery.Task, analysis_id: int, is_dependency: bool = 
         Celery task on execution (because of bind=True).
     analysis_id : int
         ID of `topobank.analysis.WorkflowResult` instance.
+    is_dependency : bool, optional
+        Whether this workflow runs as a dependency of another workflow.
+        (Default: False)
+    parent_id : int, optional
+        ID of the WorkflowResult whose scheduling triggered this run, when
+        running as a dependency. (Default: None)
     """
     from .models import RESULT_FILE_BASENAME, WorkflowResult
 
@@ -352,6 +375,7 @@ def execute_workflow(self: celery.Task, analysis_id: int, is_dependency: bool = 
                     "name": analysis.function.display_name if analysis.function else "Workflow",
                     "workflow_result_id": analysis.id,
                     "organization_id": getattr(analysis, 'owned_by_id', None),
+                    "parent_workflow_result_id": parent_id,
                 },
             )
 


### PR DESCRIPTION
## Summary

When a workflow schedules dependencies, each dependency task now carries the dispatching parent's WorkflowResult id as a `parent_id` kwarg (`schedule_workflow` → `execute_workflow`), and `execute_workflow` includes it in the `task_info` handed to the configured progress callback.

## Why

Attribution previously relied solely on the creation-time `metadata["parent_workflow_result_id"]` stamp on the dependency row. That row is shared across runs, which makes a single mutable stamp structurally wrong for per-execution attribution:

- When several parents reuse or re-run the same dependency, one field can't attribute each execution correctly — concurrent parents would clobber each other.
- Re-stamping the row races against `execute_workflow`'s full-row `save()` calls.

Carrying the parent on the Celery task itself makes attribution **immutable per execution**: each parent's chord dispatches its own id, a top-level run (dispatched without `parent_id`) can never be misclassified as a dependency, and nested dependencies attribute to their immediate parent. The creation-time stamp remains as set-once provenance and as a fallback for consumers handling tasks dispatched before this change (rolling-deploy safe: new kwargs default to `None`).

## Tests

- `task_prerun` capture over an end-to-end chord run: dependency executions carry `parent_id` of the dispatching parent and `is_dependency=True`; the top-level run carries no parent.
- A second parent force-re-running shared dependency rows attributes those executions to itself while the rows keep the creation-time stamp of the first parent — attribution neither reads from nor mutates the shared row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)