### PR TITLE
ENH: Add ignore_existing flag to submit_for_surfaces

### DIFF
--- a/tests/analysis/test_surface_set_workflows.py
+++ b/tests/analysis/test_surface_set_workflows.py
@@ -198,6 +198,30 @@ def test_submit_for_surfaces_dedups_and_force_resubmits(
 
 
 @pytest.mark.django_db
+def test_submit_for_surfaces_ignore_existing_creates_new_and_keeps_previous(
+    test_workflow, user_alice
+):
+    s1 = SurfaceFactory(created_by=user_alice)
+    s2 = SurfaceFactory(created_by=user_alice)
+
+    first = test_workflow.submit_for_surfaces(
+        user=user_alice, surfaces=[s1, s2]
+    )
+    # ignore_existing bypasses the dedup lookup entirely: it always creates a
+    # new result and, unlike force_submit, does not delete the previous one.
+    second = test_workflow.submit_for_surfaces(
+        user=user_alice, surfaces=[s1, s2], ignore_existing=True
+    )
+
+    assert second.id != first.id
+    assert second.subject_hash == first.subject_hash
+    # The prior result is preserved rather than deleted.
+    assert WorkflowResult.objects.filter(
+        id__in=[first.id, second.id]
+    ).count() == 2
+
+
+@pytest.mark.django_db
 def test_submit_for_surfaces_uses_explicit_owned_by_id(
     test_workflow, user_alice
 ):

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -896,6 +896,7 @@ class Workflow:
         kwargs: dict = None,
         owned_by_id=None,
         force_submit: bool = False,
+        ignore_existing: bool = False,
     ):
         """
         Submit workflow for a set of surfaces (new surface set system).
@@ -910,6 +911,10 @@ class Workflow:
             Keyword arguments for the workflow. (Default: None)
         force_submit : bool, optional
             Submit even if a matching WorkflowResult already exists. (Default: False)
+        ignore_existing : bool, optional
+            Skip the dedup/existing lookup entirely and always submit a new
+            WorkflowResult, without deleting any previous matching result.
+            (Default: False)
         """
         from .workflows import SurfaceSet
 
@@ -920,6 +925,11 @@ class Workflow:
         #     surface.authorize_user(user, "view")
 
         kwargs = self.clean_kwargs(kwargs)
+
+        if ignore_existing:
+            return self._submit_new_analysis_for_surfaces(
+                user, surfaces, surface_set, kwargs, owned_by_id=owned_by_id
+            )
 
         # Dedup check using subject_hash
         existing = WorkflowResult.objects.filter(


### PR DESCRIPTION
## Summary

Adds an `ignore_existing` flag to `Workflow.submit_for_surfaces`. When `True`, it skips the dedup/existing-lookup-and-delete step entirely and always submits a new `WorkflowResult`, without removing any prior matching result.

Unlike `force_submit` — which still runs the dedup query and deletes unnamed matches before submitting — `ignore_existing` bypasses the lookup completely and preserves previous results.

## Why

Enables a caller to resubmit an analysis for a subject that already has a matching result (same `workflow_name` / `subject_hash` / `kwargs`) without destroying the existing one. Consumed downstream by the SDS prediction path, where each prediction should get its own dedicated result.

## Changes

- `topobank/analysis/models.py`: new `ignore_existing` parameter with an early return before the dedup query.
- `tests/analysis/test_surface_set_workflows.py`: test verifying it creates a new result and keeps the previous one.

## Testing

`pytest tests/analysis/test_surface_set_workflows.py -k submit_for_surfaces` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)