### PR TITLE
BUG: Invalidate and reap surface-set (M2M) analyses (#1340)

### DIFF
--- a/tests/analysis/test_surface_set_invalidation.py
+++ b/tests/analysis/test_surface_set_invalidation.py
@@ -1,0 +1,135 @@
+"""
+Tests for invalidation and cleanup of surface-set (M2M) analyses (issue #1340).
+
+Surface-set analyses store their subjects via the ``WorkflowResult.surfaces``
+M2M and have ``subject_surface`` NULL, so the invalidation signals and the
+custodian must match them through the M2M, not only the legacy subject FKs.
+"""
+
+import datetime
+
+import pytest
+from django.conf import settings
+from django.utils import timezone
+
+from topobank.analysis.custodian import periodic_cleanup
+from topobank.analysis.models import WorkflowResult
+from topobank.analysis.signals import (
+    delete_all_related_analyses,
+    pre_delete_topography,
+    pre_measurement_save,
+)
+from topobank.manager.models import Topography
+from topobank.testing.factories import SurfaceFactory, Topography2DFactory
+
+
+def _surface_set_analysis(test_workflow, user, surfaces):
+    """Create a surface-set WorkflowResult over the given surfaces."""
+    return test_workflow.submit_for_surfaces(user=user, surfaces=list(surfaces))
+
+
+@pytest.mark.django_db
+def test_refresh_cache_deprecates_surface_set_analysis(test_workflow, user_alice):
+    s1 = SurfaceFactory(created_by=user_alice)
+    s2 = SurfaceFactory(created_by=user_alice)
+    other = SurfaceFactory(created_by=user_alice)
+    topo = Topography2DFactory(surface=s1)
+
+    affected = _surface_set_analysis(test_workflow, user_alice, [s1, s2])
+    unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
+    assert affected.deprecation_time is None
+
+    delete_all_related_analyses(sender=Topography, instance=topo)
+
+    affected.refresh_from_db()
+    unrelated.refresh_from_db()
+    assert affected.deprecation_time is not None
+    assert unrelated.deprecation_time is None
+
+
+@pytest.mark.django_db
+def test_new_measurement_deletes_surface_set_analysis(test_workflow, user_alice):
+    s1 = SurfaceFactory(created_by=user_alice)
+    other = SurfaceFactory(created_by=user_alice)
+
+    affected = _surface_set_analysis(test_workflow, user_alice, [s1])
+    unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
+
+    # A brand-new (unsaved) measurement added to s1.
+    new_topo = Topography(surface=s1)  # pk is None -> "created" branch
+    pre_measurement_save(sender=Topography, instance=new_topo)
+
+    assert not WorkflowResult.objects.filter(pk=affected.pk).exists()
+    assert WorkflowResult.objects.filter(pk=unrelated.pk).exists()
+
+
+@pytest.mark.django_db
+def test_new_measurement_does_not_touch_unrelated_surface_analyses(
+    test_workflow, user_alice
+):
+    """A new measurement must not delete surface/tag analyses of other surfaces.
+
+    Regression guard for the ``subject_topography=<unsaved>`` -> ``IS NULL``
+    trap: an unsaved instance must be scoped by surface only.
+    """
+    s1 = SurfaceFactory(created_by=user_alice)
+    other = SurfaceFactory(created_by=user_alice)
+    # A legacy surface analysis on a *different* surface.
+    from topobank.testing.factories import SurfaceAnalysisFactory
+
+    unrelated_surface_analysis = SurfaceAnalysisFactory(subject_surface=other)
+
+    new_topo = Topography(surface=s1)
+    pre_measurement_save(sender=Topography, instance=new_topo)
+
+    assert WorkflowResult.objects.filter(
+        pk=unrelated_surface_analysis.pk
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_delete_topography_deletes_surface_set_analysis(test_workflow, user_alice):
+    s1 = SurfaceFactory(created_by=user_alice)
+    other = SurfaceFactory(created_by=user_alice)
+    topo = Topography2DFactory(surface=s1)
+
+    affected = _surface_set_analysis(test_workflow, user_alice, [s1])
+    unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
+
+    pre_delete_topography(sender=Topography, instance=topo)
+
+    assert not WorkflowResult.objects.filter(pk=affected.pk).exists()
+    assert WorkflowResult.objects.filter(pk=unrelated.pk).exists()
+
+
+@pytest.mark.django_db
+def test_custodian_reaps_deprecated_surface_set_analysis(test_workflow, user_alice):
+    s1 = SurfaceFactory(created_by=user_alice)
+    analysis = _surface_set_analysis(test_workflow, user_alice, [s1])
+    assert analysis.subject_surface is None  # only reachable via the M2M
+
+    WorkflowResult.objects.filter(pk=analysis.pk).update(
+        deprecation_time=timezone.now()
+        - settings.TOPOBANK_ANALYSIS_DELETE_DELAY
+        - datetime.timedelta(days=1)
+    )
+
+    periodic_cleanup()
+
+    assert not WorkflowResult.objects.filter(pk=analysis.pk).exists()
+
+
+@pytest.mark.django_db
+def test_custodian_keeps_recently_deprecated_surface_set_analysis(
+    test_workflow, user_alice
+):
+    s1 = SurfaceFactory(created_by=user_alice)
+    analysis = _surface_set_analysis(test_workflow, user_alice, [s1])
+
+    WorkflowResult.objects.filter(pk=analysis.pk).update(
+        deprecation_time=timezone.now()
+    )
+
+    periodic_cleanup()
+
+    assert WorkflowResult.objects.filter(pk=analysis.pk).exists()

--- a/topobank/analysis/custodian.py
+++ b/topobank/analysis/custodian.py
@@ -17,17 +17,29 @@ def periodic_cleanup():
     analysis_delay = getattr(
         settings, "TOPOBANK_ANALYSIS_DELETE_DELAY", settings.TOPOBANK_DELETE_DELAY
     )
-    q = WorkflowResult.objects.filter(
-        deprecation_time__lt=timezone.now() - analysis_delay,
-        name__isnull=True
-    ).filter(
-        Q(subject_topography__isnull=False) | Q(subject_surface__isnull=False) | Q(subject_tag__isnull=False)
-    )
-    if q.count() > 0:
-        _log.info(
-            f"Custodian: Deleting {q.count()} analysis results because they were marked as deprecated."
+    # Resolve distinct PKs first: including the surfaces M2M in the filter
+    # introduces a join that can return a row more than once, and ``.delete()``
+    # cannot follow ``.distinct()``.
+    deprecated_pks = list(
+        WorkflowResult.objects.filter(
+            deprecation_time__lt=timezone.now() - analysis_delay,
+            name__isnull=True,
         )
-        q.delete()
+        .filter(
+            Q(subject_topography__isnull=False)
+            | Q(subject_surface__isnull=False)
+            | Q(subject_tag__isnull=False)
+            | Q(surfaces__isnull=False)
+        )
+        .values_list("pk", flat=True)
+        .distinct()
+    )
+    if deprecated_pks:
+        _log.info(
+            f"Custodian: Deleting {len(deprecated_pks)} analysis results because "
+            "they were marked as deprecated."
+        )
+        WorkflowResult.objects.filter(pk__in=deprecated_pks).delete()
 
     # Update WorkflowResults stuck in pending state with no Celery task assigned
     q = WorkflowResult.objects.filter(

--- a/topobank/analysis/signals.py
+++ b/topobank/analysis/signals.py
@@ -42,6 +42,42 @@ def post_delete_analysis(sender, instance, **kwargs):
         pass
 
 
+def _surface_scoped_analysis_pks(surface):
+    """Primary keys of analyses attached to ``surface`` (legacy FK or M2M).
+
+    A surface-set analysis over surfaces [A, B] has ``subject_surface`` NULL,
+    so it is only reachable through the ``surfaces`` M2M. ``distinct()`` is
+    required because the M2M join can return a row more than once.
+    """
+    return list(
+        WorkflowResult.objects.filter(
+            Q(subject_surface=surface) | Q(surfaces=surface)
+        )
+        .values_list("pk", flat=True)
+        .distinct()
+    )
+
+
+def _related_analysis_pks(instance):
+    """Primary keys of all analyses affected by a change to a saved topography.
+
+    Covers the topography's own analysis plus every analysis attached to its
+    surface via the legacy FK or the surface-set M2M. Only valid for a saved
+    instance (``instance.pk`` set); for a not-yet-saved measurement use
+    ``_surface_scoped_analysis_pks`` so ``subject_topography=instance`` does
+    not degenerate into an ``IS NULL`` match on unrelated analyses.
+    """
+    return list(
+        WorkflowResult.objects.filter(
+            Q(subject_topography=instance)
+            | Q(subject_surface=instance.surface)
+            | Q(surfaces=instance.surface)
+        )
+        .values_list("pk", flat=True)
+        .distinct()
+    )
+
+
 @receiver(post_refresh_cache, sender=Topography)
 def delete_all_related_analyses(sender, instance, **kwargs):
     # Cache is renewed, this means something significant changed and we need to remove
@@ -50,11 +86,10 @@ def delete_all_related_analyses(sender, instance, **kwargs):
         f"Cache of measurement {instance} was renewed: Marking all affected "
         "analyses as invalid..."
     )
-    # Use update() directly for better performance
-    WorkflowResult.objects.filter(
-        Q(subject_topography=instance)
-        | Q(subject_surface=instance.surface)
-    ).update(deprecation_time=timezone.now())
+    # Resolve distinct PKs first, then update by pk, so the M2M join cannot
+    # duplicate rows or interfere with the update.
+    pks = _related_analysis_pks(instance)
+    WorkflowResult.objects.filter(pk__in=pks).update(deprecation_time=timezone.now())
 
 
 @receiver(pre_save, sender=Topography)
@@ -62,16 +97,16 @@ def pre_measurement_save(sender, instance, **kwargs):
     created = instance.pk is None
     if created:
         # Measurement was created and added to a dataset: We need to delete the
-        # corresponding dataset analysis
-        analyses = WorkflowResult.objects.filter(subject_surface=instance.surface)
-        if analyses.exists():  # More efficient than count() > 0
-            ids = ", ".join(
-                [str(i) for i in analyses.values_list("id", flat=True)]
-            )
+        # corresponding dataset analysis (both legacy surface analyses and
+        # surface-set analyses that include this surface). The instance is not
+        # yet saved, so scope by surface only.
+        pks = _surface_scoped_analysis_pks(instance.surface)
+        analyses = WorkflowResult.objects.filter(pk__in=pks)
+        if pks:
             _log.debug(
                 "INVALIDATE WORKFLOWS: A measurement was added to dataset "
                 f"{instance.surface}: Deleting all affected workflow results with "
-                f"ids {ids}..."
+                f"ids {', '.join(str(i) for i in pks)}..."
             )
         analyses.delete()
 
@@ -82,4 +117,5 @@ def pre_delete_topography(sender, instance, **kwargs):
     # corresponding surface analysis; we do this after the transaction has finished
     # so we can check whether the surface still exists.
     _log.debug(f"Measurement {instance} was deleted: Deleting all affected analyses...")
-    WorkflowResult.objects.filter(subject_surface=instance.surface).delete()
+    pks = _related_analysis_pks(instance)
+    WorkflowResult.objects.filter(pk__in=pks).delete()


### PR DESCRIPTION
## Summary

Surface-set analyses store their subjects via the `WorkflowResult.surfaces` M2M and have `subject_surface` NULL, so the invalidation signals and the custodian only matched legacy subject FKs and never touched them. A stale surface-set result was served indefinitely after its underlying data changed.

Extends `delete_all_related_analyses`, `pre_measurement_save`, `pre_delete_topography`, and the custodian to also match the `surfaces` M2M. Distinct PKs are resolved first so the M2M join cannot duplicate rows or break `update()`/`delete()`. A not-yet-saved measurement is scoped by surface only, to avoid `subject_topography=<unsaved>` degenerating into an `IS NULL` match on unrelated analyses.

## Tests
`tests/analysis/test_surface_set_invalidation.py` — all four triggers (refresh cache, new measurement, delete topography, custodian sweep) plus a regression guard that a new measurement does not delete unrelated surface analyses.

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
