### PR TITLE
BUG: Persist pending task state when Topography.save uses update_fields (#1342)

### DIFF
--- a/tests/manager/test_topography_task_state.py
+++ b/tests/manager/test_topography_task_state.py
@@ -1,0 +1,68 @@
+"""
+Tests for issue #1342: Topography.save() with a restricted update_fields must
+still persist the pending task state that run_task sets in memory.
+
+Otherwise a recompute is dispatched while the DB keeps task_state=SUCCESS
+(get_task_state() then wrongly reports "done"), and the in-flight re-dispatch
+guard — which keys off the persisted task_state — fails to prevent a second
+concurrent edit from double-dispatching.
+"""
+
+import pytest
+
+from topobank.manager.models import Topography
+from topobank.testing.factories import Topography2DFactory
+
+
+@pytest.mark.django_db
+def test_save_update_fields_persists_pending_state():
+    topo = Topography2DFactory()
+    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    topo.refresh_from_db()
+    assert topo.task_state == Topography.SUCCESS
+
+    # A significant field changes, saved with a restricted update_fields.
+    topo.size_x = topo.size_x + 1
+    topo.save(update_fields=["size_x"])
+
+    reloaded = Topography.objects.get(pk=topo.pk)
+    assert reloaded.task_state == Topography.PENDING  # pending state persisted
+    assert reloaded.size_x == topo.size_x  # the requested field still saved
+
+
+@pytest.mark.django_db
+def test_save_update_fields_no_change_keeps_state():
+    """A save with update_fields that does not touch a significant field must
+    not spuriously flip the state to pending."""
+    topo = Topography2DFactory()
+    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    topo.refresh_from_db()
+
+    topo.name = "renamed"  # not a significant field
+    topo.save(update_fields=["name"])
+
+    assert Topography.objects.get(pk=topo.pk).task_state == Topography.SUCCESS
+
+
+@pytest.mark.django_db
+def test_persisted_pending_state_enables_inflight_guard():
+    """Once the pending state is persisted, a concurrent handle sees it and is
+    guarded from re-dispatching (run_task skips set_pending_state)."""
+    topo = Topography2DFactory()
+    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    topo.refresh_from_db()
+
+    topo.size_x += 1
+    topo.save(update_fields=["size_x"])
+    assert Topography.objects.get(pk=topo.pk).task_state == Topography.PENDING
+    submission_before = Topography.objects.get(pk=topo.pk).task_submission_time
+
+    # A separate handle (concurrent worker) sees PENDING; its save must not
+    # reset the submission time, i.e. no second dispatch is set up.
+    concurrent = Topography.objects.get(pk=topo.pk)
+    concurrent.size_x += 1
+    concurrent.save(update_fields=["size_x"])
+
+    assert (
+        Topography.objects.get(pk=topo.pk).task_submission_time == submission_before
+    )

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -908,6 +908,16 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         # Check if we need to run the update task
         if refresh_dependent_data:
             run_task(self)
+            # run_task sets the pending task state in memory (autosave=False),
+            # expecting this save() to persist it. When the caller restricted
+            # update_fields (e.g. save(update_fields=["size_x"])) those fields
+            # would otherwise be dropped, leaving task_state stale (reported as
+            # SUCCESS while a recompute is in flight) and defeating the in-flight
+            # re-dispatch guard, which keys off the persisted task_state.
+            if update_fields is not None:
+                for name in TaskStateModel.PENDING_STATE_FIELDS:
+                    if name not in update_fields:
+                        update_fields.append(name)
 
         # Save after run task, because run task may update the task state
         super().save(*args, **kwargs)

--- a/topobank/taskapp/models.py
+++ b/topobank/taskapp/models.py
@@ -49,6 +49,19 @@ class TaskStateModel(models.Model):
     # original (now-stale) task_start_time.
     IN_FLIGHT_STATES = (PENDING, PENDING_DEPENDENCIES, STARTED)
 
+    # Fields mutated by set_pending_state(). Callers that persist with a
+    # restricted update_fields must include these, otherwise the pending
+    # transition is silently dropped.
+    PENDING_STATE_FIELDS = (
+        "task_state",
+        "task_submission_time",
+        "task_error",
+        "task_traceback",
+        "task_id",
+        "task_start_time",
+        "task_end_time",
+    )
+
     # Mapping Celery states to our state information. Everything not in the
     # list (e.g. custom Celery states) are interpreted as STARTED.
     _CELERY_STATE_MAP = {
@@ -411,17 +424,7 @@ class TaskStateModel(models.Model):
         self.task_start_time = None
         self.task_end_time = None
         if autosave:
-            self.save(
-                update_fields=[
-                    "task_state",
-                    "task_submission_time",
-                    "task_error",
-                    "task_traceback",
-                    "task_id",
-                    "task_start_time",
-                    "task_end_time",
-                ]
-            )
+            self.save(update_fields=list(self.PENDING_STATE_FIELDS))
 
     def get_task_error(self):
         """Return a string representation of any error occurred during task execution"""


### PR DESCRIPTION
## Summary

`run_task()` sets the pending task state in memory (`autosave=False`), expecting the caller's `save()` to persist it. When `Topography.save()` was called with a restricted `update_fields` (e.g. `save(update_fields=["size_x"])`), the task-state fields were dropped: `task_state` stayed SUCCESS while a recompute was in flight, and the in-flight re-dispatch guard (which keys off the persisted `task_state`) could not prevent a second concurrent edit from double-dispatching.

Extends `update_fields` with the pending-state fields whenever a recompute is dispatched. Introduces `TaskStateModel.PENDING_STATE_FIELDS` as the single source of truth for that field set and reuses it in `set_pending_state()`.

## Tests
`tests/manager/test_topography_task_state.py` — persistence under `update_fields`, no spurious flip on a non-significant field, and that the persisted pending state makes the in-flight guard effective (no double dispatch).

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
