### PR TITLE
BUG: Serialize check-then-create dedup to prevent duplicate results (#1343)

### DIFF
--- a/tests/analysis/test_submit_dedup_race.py
+++ b/tests/analysis/test_submit_dedup_race.py
@@ -1,0 +1,86 @@
+"""
+Tests for issue #1343: the check-then-create dedup in submit /
+submit_for_surfaces must be serialized so concurrent identical submissions do
+not create duplicate WorkflowResults.
+"""
+
+import threading
+
+import pytest
+from django.db import connection
+
+from topobank.analysis.models import WorkflowResult
+from topobank.supplib.db import _advisory_lock_key, advisory_lock
+from topobank.testing.factories import SurfaceFactory
+
+
+def test_advisory_lock_key_is_deterministic_and_in_bigint_range():
+    a = _advisory_lock_key("workflow-submit", "wf", "surfaces:abc", "{}")
+    b = _advisory_lock_key("workflow-submit", "wf", "surfaces:abc", "{}")
+    c = _advisory_lock_key("workflow-submit", "wf", "surfaces:xyz", "{}")
+    assert a == b
+    assert a != c
+    assert -(2**63) <= a < 2**63
+
+
+@pytest.mark.django_db
+def test_advisory_lock_is_a_noop_context_manager():
+    # Simply exercising the context manager must not raise (postgres executes
+    # the lock; other backends no-op).
+    with advisory_lock("test", 1, 2):
+        pass
+
+
+@pytest.mark.django_db
+def test_submit_for_surfaces_is_idempotent(test_workflow, user_alice):
+    """Regression guard that wrapping the dedup in a lock did not break the
+    sequential dedup behaviour."""
+    s1 = SurfaceFactory(created_by=user_alice)
+    first = test_workflow.submit_for_surfaces(user=user_alice, surfaces=[s1])
+    second = test_workflow.submit_for_surfaces(user=user_alice, surfaces=[s1])
+    assert first.id == second.id
+    assert WorkflowResult.objects.filter(subject_hash=first.subject_hash).count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_submit_for_surfaces_creates_single_result(
+    test_workflow, user_alice
+):
+    """Two threads submitting the same surface set concurrently must end up
+    with exactly one WorkflowResult (the advisory lock serializes them)."""
+    if connection.vendor != "postgresql":
+        pytest.skip("advisory locks require PostgreSQL")
+
+    s1 = SurfaceFactory(created_by=user_alice)
+    surfaces = [s1]
+
+    barrier = threading.Barrier(2)
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=10)
+            wr = test_workflow.submit_for_surfaces(user=user_alice, surfaces=surfaces)
+            results.append(wr.id)
+        except Exception as exc:  # pragma: no cover - surfaced via assertion
+            errors.append(exc)
+        finally:
+            connection.close()
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, errors
+    assert len(results) == 2
+    # Both submissions resolve to a single stored result.
+    assert (
+        WorkflowResult.objects.filter(
+            workflow_name=test_workflow.name
+        ).count()
+        == 1
+    )
+    assert results[0] == results[1]

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -22,6 +22,7 @@ from ..authorization.mixins import PermissionMixin
 from ..authorization.models import AuthorizedManager, ViewEditFull
 from ..files.models import Manifest, ManifestSet
 from ..manager.models import Surface, Tag, Topography
+from ..supplib.db import advisory_lock
 from ..supplib.dict import load_split_dict, store_split_dict
 from ..taskapp.models import Configuration, TaskStateModel
 from .registry import WorkflowNotImplementedException, get_implementation
@@ -807,35 +808,53 @@ class Workflow:
         if isinstance(subject, Tag):
             q &= Q(permissions__user_permissions__user=user)
 
-        # All existing WorkflowResults for this subject and parameter set
-        existing_analyses = WorkflowResult.objects.for_user(user).filter(q)
+        # Serialize the check-then-create against concurrent identical
+        # submissions. Without this, two requests for the same
+        # subject/workflow/kwargs can both observe "no viable result", both
+        # delete the failed set and both create+dispatch a new WorkflowResult,
+        # producing duplicate rows and duplicate compute. The advisory lock is
+        # released when the surrounding transaction commits.
+        with transaction.atomic(), advisory_lock(
+            "workflow-submit",
+            self.name,
+            f"{type(subject).__name__}:{subject.id}",
+            json.dumps(kwargs, sort_keys=True, default=str),
+        ):
+            # All existing WorkflowResults for this subject and parameter set
+            existing_analyses = WorkflowResult.objects.for_user(user).filter(q)
 
-        # WorkflowResults, excluding those that have failed or that have not been submitted
-        # to the task queue for some reason (state "no"t run)
-        successful_or_running_analyses = existing_analyses.filter(
-            task_state__in=[
-                WorkflowResult.PENDING,
-                WorkflowResult.PENDING_DEPENDENCIES,
-                WorkflowResult.RETRY,
-                WorkflowResult.STARTED,
-                WorkflowResult.SUCCESS,
-            ]
-        )
+            # WorkflowResults, excluding those that have failed or that have not
+            # been submitted to the task queue for some reason (state "no"t run)
+            successful_or_running_analyses = existing_analyses.filter(
+                task_state__in=[
+                    WorkflowResult.PENDING,
+                    WorkflowResult.PENDING_DEPENDENCIES,
+                    WorkflowResult.RETRY,
+                    WorkflowResult.STARTED,
+                    WorkflowResult.SUCCESS,
+                ]
+            )
 
-        # We submit a new WorkflowResult only if we are either forced to do so or if there is
-        # no WorkflowResult with the same parameter pending, running or successfully completed.
-        if force_submit or successful_or_running_analyses.count() == 0:
-            # Delete *all* existing WorkflowResults with this subject/parameter set
-            # (which now may only contain failed ones),
-            # excluding saved/named ones (name__isnull is a redundant since all saved
-            # analyses no longer have subjects)
-            existing_analyses.filter(name__isnull=True).delete()
+            # We submit a new WorkflowResult only if we are either forced to do
+            # so or if there is no WorkflowResult with the same parameter
+            # pending, running or successfully completed.
+            if force_submit or successful_or_running_analyses.count() == 0:
+                # Delete *all* existing WorkflowResults with this subject/parameter
+                # set (which now may only contain failed ones), excluding
+                # saved/named ones (name__isnull is redundant since all saved
+                # analyses no longer have subjects)
+                existing_analyses.filter(name__isnull=True).delete()
 
-            return self._submit_new_analysis(user, subject, kwargs)
-        else:
-            # There seem to be viable analyses. Fetch the latest one.
-            analysis = existing_analyses.order_by("task_start_time").last()
-            return analysis
+                return self._submit_new_analysis(user, subject, kwargs)
+            else:
+                # There seem to be viable analyses. Fetch the latest one. Select
+                # from the successful/running set, not from all existing analyses:
+                # NULL task_start_time (never-run rows) sort last in PostgreSQL,
+                # so .last() over the full set could return a NOTRUN row instead
+                # of an available SUCCESS one.
+                return successful_or_running_analyses.order_by(
+                    "task_start_time"
+                ).last()
 
     def _submit_new_analysis(
         self,
@@ -931,30 +950,40 @@ class Workflow:
                 user, surfaces, surface_set, kwargs, owned_by_id=owned_by_id
             )
 
-        # Dedup check using subject_hash
-        existing = WorkflowResult.objects.filter(
-            workflow_name=self.name,
-            subject_hash=surface_set.subject_hash,
-            kwargs=kwargs,
-        )
-
-        successful_or_running = existing.filter(
-            task_state__in=[
-                WorkflowResult.PENDING,
-                WorkflowResult.PENDING_DEPENDENCIES,
-                WorkflowResult.RETRY,
-                WorkflowResult.STARTED,
-                WorkflowResult.SUCCESS,
-            ]
-        )
-
-        if force_submit or successful_or_running.count() == 0:
-            existing.filter(name__isnull=True).delete()
-            return self._submit_new_analysis_for_surfaces(
-                user, surfaces, surface_set, kwargs, owned_by_id=owned_by_id
+        # Serialize the check-then-create against concurrent identical
+        # submissions (see Workflow.submit for the rationale). The advisory lock
+        # is released when the surrounding transaction commits.
+        with transaction.atomic(), advisory_lock(
+            "workflow-submit-surfaces",
+            self.name,
+            surface_set.subject_hash,
+            json.dumps(kwargs, sort_keys=True, default=str),
+        ):
+            # Dedup check using subject_hash
+            existing = WorkflowResult.objects.filter(
+                workflow_name=self.name,
+                subject_hash=surface_set.subject_hash,
+                kwargs=kwargs,
             )
-        else:
-            return existing.order_by("task_start_time").last()
+
+            successful_or_running = existing.filter(
+                task_state__in=[
+                    WorkflowResult.PENDING,
+                    WorkflowResult.PENDING_DEPENDENCIES,
+                    WorkflowResult.RETRY,
+                    WorkflowResult.STARTED,
+                    WorkflowResult.SUCCESS,
+                ]
+            )
+
+            if force_submit or successful_or_running.count() == 0:
+                existing.filter(name__isnull=True).delete()
+                return self._submit_new_analysis_for_surfaces(
+                    user, surfaces, surface_set, kwargs, owned_by_id=owned_by_id
+                )
+            else:
+                # Select from the successful/running set (see Workflow.submit).
+                return successful_or_running.order_by("task_start_time").last()
 
     def _submit_new_analysis_for_surfaces(
         self,

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -1,3 +1,4 @@
+import json
 import traceback
 import tracemalloc
 from typing import Any, Dict
@@ -10,6 +11,7 @@ from django.utils import timezone
 from SurfaceTopography.Support import doi
 
 from ..manager.models import Surface, Tag, Topography
+from ..supplib.db import advisory_lock
 from ..supplib.dict import store_split_dict
 from ..taskapp.celeryapp import app
 from ..taskapp.models import Configuration
@@ -607,10 +609,22 @@ def prepare_dependency_tasks(
         ).select_related("subject_topography", "subject_surface", "subject_tag")
         if use_surfaces_path and isinstance(subject, Surface):
             existing_analysis_qs = existing_analysis_qs.prefetch_related("surfaces")
-        existing_analysis = existing_analysis_qs.order_by("-task_start_time").first()
+        # Serialize the existence check and creation of this dependency against
+        # concurrent parents needing the same dependency. Without this, two
+        # parents can both observe "no existing dependency" and each create a
+        # separate dependency analysis, doubling the work. The advisory lock is
+        # released when the surrounding transaction commits.
+        with transaction.atomic(), advisory_lock(
+            "dependency",
+            function.name,
+            subject_hash,
+            json.dumps(kwargs, sort_keys=True, default=str),
+        ):
+            existing_analysis = existing_analysis_qs.order_by(
+                "-task_start_time"
+            ).first()
 
-        if existing_analysis is None:
-            with transaction.atomic():
+            if existing_analysis is None:
                 create_kwargs = dict(
                     permissions=parent.permissions,
                     workflow_name=function.name,
@@ -635,20 +649,21 @@ def prepare_dependency_tasks(
                 if use_surfaces_path and isinstance(subject, Surface):
                     # M2M fields cannot be set until after the instance is created.
                     new_analysis.surfaces.set([subject])
-            scheduled_dependent_analyses[key] = new_analysis
-        else:
-            # An analysis exists. Check whether it is successful or failed.
-            # task_state is the *self reported* state, not the Celery state
-            if not force and existing_analysis.task_state in [
-                WorkflowResult.FAILURE,
-                WorkflowResult.SUCCESS,
-            ]:
-                # This one does not need to be scheduled
-                finished_dependent_analyses[key] = existing_analysis
+                scheduled_dependent_analyses[key] = new_analysis
             else:
-                # We schedule everything else, possibly again. `perform_analysis` will
-                # automatically terminate if an analysis already completed successfully.
-                scheduled_dependent_analyses[key] = existing_analysis
+                # An analysis exists. Check whether it is successful or failed.
+                # task_state is the *self reported* state, not the Celery state
+                if not force and existing_analysis.task_state in [
+                    WorkflowResult.FAILURE,
+                    WorkflowResult.SUCCESS,
+                ]:
+                    # This one does not need to be scheduled
+                    finished_dependent_analyses[key] = existing_analysis
+                else:
+                    # We schedule everything else, possibly again.
+                    # `perform_analysis` will automatically terminate if an
+                    # analysis already completed successfully.
+                    scheduled_dependent_analyses[key] = existing_analysis
 
     return (
         finished_dependent_analyses,

--- a/topobank/supplib/db.py
+++ b/topobank/supplib/db.py
@@ -1,0 +1,39 @@
+"""Small database helpers shared across apps."""
+
+import contextlib
+import hashlib
+
+from django.db import connection
+
+
+def _advisory_lock_key(*parts) -> int:
+    """Map arbitrary parts to a signed 64-bit int for pg_advisory_xact_lock.
+
+    PostgreSQL advisory locks are keyed by a bigint, so we hash the string
+    representation of the parts into the signed 64-bit range.
+    """
+    key = "\x00".join(str(p) for p in parts)
+    digest = hashlib.sha256(key.encode()).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+@contextlib.contextmanager
+def advisory_lock(*parts):
+    """Serialize a critical section across processes with a PostgreSQL
+    transaction-level advisory lock.
+
+    Must be used inside a ``transaction.atomic()`` block; the lock is released
+    automatically when that transaction commits or rolls back. Concurrent
+    callers requesting the same key block until the holder's transaction ends,
+    which lets a check-then-create critical section run without racing.
+
+    On non-PostgreSQL backends this is a no-op (advisory locks are
+    Postgres-specific), so behavior degrades to the previous unserialized
+    check-then-create rather than erroring.
+    """
+    if connection.vendor == "postgresql":
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_advisory_xact_lock(%s)", [_advisory_lock_key(*parts)]
+            )
+    yield


### PR DESCRIPTION
## Summary

`submit()`, `submit_for_surfaces()` and `prepare_dependency_tasks()` performed a non-atomic read (count/first) then delete/create with no lock and no unique constraint. Concurrent identical submissions could each observe "no viable result" and both create+dispatch a `WorkflowResult`, producing duplicate rows and duplicate compute; two parents needing the same dependency could each create a separate dependency analysis.

Wraps each check-then-create in `transaction.atomic()` guarded by a PostgreSQL transaction-level advisory lock keyed on `(workflow_name, subject, kwargs)`. Adds `topobank.supplib.db.advisory_lock` as the shared helper (no-op on non-PostgreSQL backends).

## Tests
`tests/analysis/test_submit_dedup_race.py` — includes a real two-thread concurrency test asserting a single stored result, plus lock-key/idempotency unit tests.

## Ordering
- Land #1341 first (same methods; this branch already matches its fix).
- This PR and #1344 both add `supplib/db.py` (identical file) — land one first and rebase the other.

Closes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
