### PR TITLE
BUG: De-duplicate Configuration creation under concurrency (#1344)

### DIFF
--- a/tests/analysis/test_configuration_race.py
+++ b/tests/analysis/test_configuration_race.py
@@ -1,0 +1,52 @@
+"""
+Tests for issue #1344: get_current_configuration must not create duplicate
+Configuration rows under concurrency, and must never expose a Configuration
+with an empty versions set.
+"""
+
+import threading
+
+import pytest
+from django.db import connection
+
+from topobank.analysis.tasks import get_current_configuration
+from topobank.taskapp.models import Configuration
+
+
+@pytest.mark.django_db
+def test_get_current_configuration_reuses_existing():
+    c1 = get_current_configuration()
+    c2 = get_current_configuration()
+    assert c1.id == c2.id
+    assert Configuration.objects.count() == 1
+    # The stored configuration always carries its versions.
+    assert c1.versions.count() > 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_get_current_configuration_creates_single_row():
+    if connection.vendor != "postgresql":
+        pytest.skip("advisory locks require PostgreSQL")
+
+    barrier = threading.Barrier(4)
+    ids = []
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=10)
+            ids.append(get_current_configuration().id)
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+        finally:
+            connection.close()
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, errors
+    assert Configuration.objects.count() == 1
+    assert len(set(ids)) == 1

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from SurfaceTopography.Support import doi
 
 from ..manager.models import Surface, Tag, Topography
+from ..supplib.db import advisory_lock
 from ..supplib.dict import store_split_dict
 from ..taskapp.celeryapp import app
 from ..taskapp.models import Configuration
@@ -42,21 +43,24 @@ def get_current_configuration():
         c.versions.set(versions)
         return c
 
-    if Configuration.objects.count() == 0:
-        return make_config_from_versions()
-
-    #
-    # Find out whether the latest configuration has exactly these versions
-    #
-    latest_config = Configuration.objects.latest("valid_since")
-
+    # Serialize the check-then-create so concurrent workers (e.g. right after a
+    # dependency version bump) do not each create a redundant Configuration for
+    # the same version set. Doing the create and versions.set() inside one
+    # transaction also means a Configuration is never observed with an empty
+    # versions set. The advisory lock is released when the transaction commits.
     current_version_ids = set(v.id for v in versions)
-    latest_version_ids = set(v.id for v in latest_config.versions.all())
+    with transaction.atomic(), advisory_lock("current-configuration"):
+        if Configuration.objects.count() == 0:
+            return make_config_from_versions()
 
-    if current_version_ids == latest_version_ids:
-        return latest_config
-    else:
-        return make_config_from_versions()
+        # Find out whether the latest configuration has exactly these versions
+        latest_config = Configuration.objects.latest("valid_since")
+        latest_version_ids = set(v.id for v in latest_config.versions.all())
+
+        if current_version_ids == latest_version_ids:
+            return latest_config
+        else:
+            return make_config_from_versions()
 
 
 @app.task(bind=True, soft_time_limit=3600, time_limit=3700)

--- a/topobank/supplib/db.py
+++ b/topobank/supplib/db.py
@@ -1,0 +1,39 @@
+"""Small database helpers shared across apps."""
+
+import contextlib
+import hashlib
+
+from django.db import connection
+
+
+def _advisory_lock_key(*parts) -> int:
+    """Map arbitrary parts to a signed 64-bit int for pg_advisory_xact_lock.
+
+    PostgreSQL advisory locks are keyed by a bigint, so we hash the string
+    representation of the parts into the signed 64-bit range.
+    """
+    key = "\x00".join(str(p) for p in parts)
+    digest = hashlib.sha256(key.encode()).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+@contextlib.contextmanager
+def advisory_lock(*parts):
+    """Serialize a critical section across processes with a PostgreSQL
+    transaction-level advisory lock.
+
+    Must be used inside a ``transaction.atomic()`` block; the lock is released
+    automatically when that transaction commits or rolls back. Concurrent
+    callers requesting the same key block until the holder's transaction ends,
+    which lets a check-then-create critical section run without racing.
+
+    On non-PostgreSQL backends this is a no-op (advisory locks are
+    Postgres-specific), so behavior degrades to the previous unserialized
+    check-then-create rather than erroring.
+    """
+    if connection.vendor == "postgresql":
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_advisory_xact_lock(%s)", [_advisory_lock_key(*parts)]
+            )
+    yield


### PR DESCRIPTION
## Summary

`get_current_configuration()` did a non-atomic count/latest then create, so concurrent workers (e.g. right after a dependency version bump) could each create a redundant `Configuration` for the same version set, and a config could be briefly observed with an empty `versions` M2M between `create()` and `set()`.

Wraps the check-then-create in `transaction.atomic()` guarded by an advisory lock; the create and `versions.set()` now commit atomically.

## Tests
`tests/analysis/test_configuration_race.py` — reuse-existing plus a real four-thread test asserting a single Configuration row.

## Ordering
Introduces `topobank.supplib.db.advisory_lock`, also added by #1343 (identical file). Land one first and rebase the other.

Closes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
