### PR TITLE
BUG: Preserve failed dependency's traceback on the parent (#1345)

### DIFF
--- a/tests/analysis/test_dependency_traceback.py
+++ b/tests/analysis/test_dependency_traceback.py
@@ -1,0 +1,87 @@
+"""
+Tests for issue #1345: when a workflow fails because a dependency failed, the
+parent must surface the dependency's real error/traceback, not a generic one.
+"""
+
+import pytest
+
+from topobank.analysis.models import Workflow, WorkflowResult
+from topobank.analysis.tasks import execute_workflow, schedule_workflow
+from topobank.testing.factories import TopographyAnalysisFactory
+
+DEP_TRACEBACK = "DEP TRACEBACK: exploded at line 42"
+DEP_ERROR = "boom in dep"
+
+
+def _pending(topo, workflow_name="topobank.testing.test", **kwargs):
+    from topobank.analysis.models import Workflow
+
+    wf = Workflow(name=workflow_name)
+    return TopographyAnalysisFactory.create(
+        subject_topography=topo,
+        workflow_name=workflow_name,
+        kwargs=wf.get_default_kwargs(),
+        result=None,
+        task_state=WorkflowResult.PENDING,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_parent_preserves_dependency_traceback_on_execute(two_topos, test_workflow):
+    topo, _ = two_topos
+
+    dep = _pending(topo)
+    WorkflowResult.objects.filter(pk=dep.pk).update(
+        task_state=WorkflowResult.FAILURE,
+        task_error=DEP_ERROR,
+        task_traceback=DEP_TRACEBACK,
+    )
+
+    parent = _pending(topo)
+    parent.dependencies = {"0": dep.id}
+    parent.save()
+
+    # execute_workflow finds the failed dependency and must fail the parent
+    # while carrying the dependency's real error/traceback.
+    execute_workflow.apply(args=(parent.id,))
+
+    parent.refresh_from_db()
+    assert parent.task_state == WorkflowResult.FAILURE
+    assert parent.task_error == DEP_ERROR
+    assert parent.task_traceback == DEP_TRACEBACK
+
+
+@pytest.mark.django_db
+def test_schedule_workflow_copies_finished_failed_dependency_traceback(two_topos):
+    """When dependencies already exist in a finished FAILURE state, the parent
+    must inherit the failed dependency's error/traceback, not a generic message.
+    """
+    topo, _ = two_topos
+    dep_wf = Workflow(name="topobank.testing.test")
+    subject_hash = WorkflowResult.compute_subject_hash("topography", [topo.id])
+
+    # Pre-create the two dependencies "topobank.testing.test2" declares, matching
+    # the (workflow_name, subject_hash, kwargs) that prepare_dependency_tasks
+    # looks up, already in a FAILED state.
+    for dep_kwargs in [dict(a=1), dict(b="A")]:
+        dep = TopographyAnalysisFactory.create(
+            subject_topography=topo,
+            workflow_name="topobank.testing.test",
+            kwargs=dep_wf.clean_kwargs(dep_kwargs),
+            subject_hash=subject_hash,
+            result=None,
+            task_state=WorkflowResult.FAILURE,
+        )
+        WorkflowResult.objects.filter(pk=dep.pk).update(
+            task_error=DEP_ERROR, task_traceback=DEP_TRACEBACK
+        )
+
+    parent = _pending(topo, "topobank.testing.test2")
+
+    schedule_workflow.apply(args=(parent.id, False))
+
+    parent.refresh_from_db()
+    assert parent.task_state == WorkflowResult.FAILURE
+    assert parent.task_error == DEP_ERROR
+    assert parent.task_traceback == DEP_TRACEBACK

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -203,12 +203,19 @@ def schedule_workflow(
         analysis.save()
 
         # Check if any dependency failed
-        if any(
-            dep.task_state != WorkflowResult.SUCCESS
+        failed_dependencies = [
+            dep
             for dep in finished_dependencies.values()
-        ):
+            if dep.task_state != WorkflowResult.SUCCESS
+        ]
+        if failed_dependencies:
+            # Surface the failed dependency's real error/traceback on the parent
+            # rather than a generic message, so the UI shows why it failed
+            # (mirrors execute_workflow and _fail_parent_on_dependency_failure).
+            failed_dep = failed_dependencies[0]
             analysis.task_state = WorkflowResult.FAILURE
-            analysis.task_error = "A dependent analysis failed."
+            analysis.task_error = failed_dep.task_error or "A dependent analysis failed."
+            analysis.task_traceback = failed_dep.task_traceback
             analysis.save()
             _log.debug(f"{analysis_id}/{self.request.id}: A dependency failed.")
             return


### PR DESCRIPTION
## Summary

When a parent's dependencies already exist in a finished FAILURE state, `schedule_workflow` marked the parent FAILURE with a generic `"A dependent analysis failed."` message and copied no traceback, so the UI could not show why it failed. Now copies the failed dependency's `task_error` and `task_traceback` onto the parent, mirroring `execute_workflow` and `_fail_parent_on_dependency_failure`.

Note: the `execute_workflow` path the original issue cited already preserved the traceback (the `raise` there is outside the `try`, so the `except` never overwrites it) — verified against `main`. The real gap was in `schedule_workflow`. A regression test documents both paths.

## Tests
`tests/analysis/test_dependency_traceback.py` — the `schedule_workflow` "already-finished failed dependency" path (fails on `main`, passes here) and a guard for the already-correct `execute_workflow` path.

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
