### PR TITLE
BUG: Fix _get_unique_kwargs aliasing and key-intersection (#1346)

### DIFF
--- a/tests/analysis/test_unique_kwargs.py
+++ b/tests/analysis/test_unique_kwargs.py
@@ -1,0 +1,50 @@
+"""
+Tests for issue #1346: AnalysisController._get_unique_kwargs must return the
+true intersection of kwargs across analyses (dropping keys absent from or
+differing in any analysis) without mutating any analysis's stored kwargs.
+"""
+
+from types import SimpleNamespace
+
+from topobank.analysis.controller import AnalysisController
+
+
+def _controller_with(kwargs_list):
+    ctrl = AnalysisController.__new__(AnalysisController)
+    ctrl._analyses = [SimpleNamespace(kwargs=k) for k in kwargs_list]
+    return ctrl
+
+
+def test_unique_kwargs_drops_keys_absent_from_a_later_analysis():
+    unique, has_nonunique = _controller_with([{"a": 1, "b": 2}, {"a": 1}])._get_unique_kwargs()
+    assert unique == {"a": 1}
+    assert has_nonunique is True
+
+
+def test_unique_kwargs_drops_differing_values():
+    unique, has_nonunique = _controller_with(
+        [{"a": 1, "b": 2}, {"a": 9, "b": 2}]
+    )._get_unique_kwargs()
+    assert unique == {"b": 2}
+    assert has_nonunique is True
+
+
+def test_unique_kwargs_keeps_all_when_identical():
+    unique, has_nonunique = _controller_with([{"a": 1}, {"a": 1}])._get_unique_kwargs()
+    assert unique == {"a": 1}
+    assert has_nonunique is False
+
+
+def test_unique_kwargs_empty_when_no_analyses():
+    unique, has_nonunique = _controller_with([])._get_unique_kwargs()
+    assert unique == {}
+    assert has_nonunique is False
+
+
+def test_unique_kwargs_does_not_mutate_source_dicts():
+    first = {"a": 1, "b": 2}
+    second = {"a": 9, "b": 2}
+    _controller_with([first, second])._get_unique_kwargs()
+    # The stored kwargs must be untouched (no aliasing / in-place deletion).
+    assert first == {"a": 1, "b": 2}
+    assert second == {"a": 9, "b": 2}

--- a/topobank/analysis/controller.py
+++ b/topobank/analysis/controller.py
@@ -279,22 +279,26 @@ class AnalysisController:
 
     def _get_unique_kwargs(self):
         """
-        Collect all keyword arguments and check whether they are equal.
-        Returns a dictionary with unique keyword arguments.
+        Collect all keyword arguments and return only those that are common to
+        every analysis with an identical value.
+
+        A key is kept only if it is present in *all* analyses with the same
+        value; a key that is missing from, or differs in, any analysis is
+        dropped. The returned dict is a fresh copy, so callers may mutate it
+        without touching any analysis's stored ``kwargs``.
         """
         unique_kwargs = None
         has_nonunique_kwargs = False
         for analysis in self._analyses:
             kwargs = analysis.kwargs
             if unique_kwargs is None:
-                unique_kwargs = kwargs
+                unique_kwargs = dict(kwargs)  # copy: never alias analysis.kwargs
             else:
-                for key, value in kwargs.items():
-                    if key in unique_kwargs:
-                        if unique_kwargs[key] != value:
-                            # Delete nonunique key
-                            del unique_kwargs[key]
-                            has_nonunique_kwargs = True
+                for key in list(unique_kwargs):
+                    if key not in kwargs or kwargs[key] != unique_kwargs[key]:
+                        # Drop keys that are absent from or differ in this analysis
+                        del unique_kwargs[key]
+                        has_nonunique_kwargs = True
         return {} if unique_kwargs is None else unique_kwargs, has_nonunique_kwargs
 
     def trigger_missing_analyses(self):


### PR DESCRIPTION
## Summary

`_get_unique_kwargs` aliased the first analysis's `kwargs` dict (mutating it via `del`) and only dropped a key when a later analysis had it with a *different* value — keys absent from a later analysis were never dropped, so the result could contain kwargs not common to all analyses (and `trigger_missing_analyses` could then trigger with non-common kwargs).

Now copies the first dict and drops any key that is missing from or differs in any analysis, yielding the true intersection without mutating stored kwargs.

## Tests
`tests/analysis/test_unique_kwargs.py` — absent-key drop, differing-value drop, all-identical, empty, and a no-source-mutation guard.

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
