### PR TITLE
BUG: Fix workflow crash on `timer` kwarg and record per-workflow timing

### DIFF
--- a/tests/analysis/test_tasks.py
+++ b/tests/analysis/test_tasks.py
@@ -148,6 +148,39 @@ def test_schedule_workflow_runs_dependencies_end_to_end(two_topos, test_workflow
 
 
 # ---------------------------------------------------------------------------
+# Timing (regression: workflows must not crash on the `timer` kwarg, and
+# must produce timing information)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_workflow_produces_timing_information(two_topos, test_workflow):
+    """Running a workflow records hierarchical timing into ``task_timer``.
+
+    The task runner passes a ``muTimer.Timer`` into the workflow; the base
+    ``eval`` wraps the implementation call so every workflow gets a top-level
+    timing node named after itself, and implementations that opt in (accept a
+    ``timer`` argument) nest their own sub-steps underneath.
+    """
+    topo = Topography.objects.first()
+    analysis = _pending_analysis(topo, "topobank.testing.test")
+
+    perform_analysis.apply(args=(analysis.id, True))
+
+    analysis.refresh_from_db()
+    assert analysis.task_state == WorkflowResult.SUCCESS
+
+    # muTimer.to_dict() -> {"timers": [ {name, ..., children: [...]}, ... ]}
+    assert analysis.task_timer is not None
+    timers = analysis.task_timer["timers"]
+    workflow_node = next(t for t in timers if t["name"] == "topobank.testing.test")
+    assert workflow_node["total_seconds"] >= 0
+    # The test implementation times two sub-steps, which nest under the workflow.
+    child_names = {c["name"] for c in workflow_node.get("children", [])}
+    assert {"save_file1", "save_file2"} <= child_names
+
+
+# ---------------------------------------------------------------------------
 # Dependency FAILURE propagation (regression: parent must not hang)
 # ---------------------------------------------------------------------------
 

--- a/topobank/analysis/legacy/workflows.py
+++ b/topobank/analysis/legacy/workflows.py
@@ -4,6 +4,7 @@ WorkflowImplementation base class and helpers.
 
 import collections
 import hashlib
+import inspect
 import logging
 import warnings
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from typing import Union
 
 import numpy as np
 import pydantic
+from muTimer import Timer
 from pydantic import field_validator
 
 from ...manager.models import Surface, Tag, Topography
@@ -177,11 +179,38 @@ class WorkflowImplementation:
     def kwargs(self):
         return self._kwargs
 
+    def _run_implementation(self, implementation, analysis, auxiliary_kwargs):
+        """Invoke an implementation method with timing.
+
+        The caller (the task runner) provides a ``timer`` (a ``muTimer.Timer``
+        instance) via ``auxiliary_kwargs``. It is exposed to implementations as
+        ``self.timer`` (so they can time individual steps, which nest under the
+        workflow node) and is used here to record the total run time of the
+        workflow under its name. Only keyword arguments the implementation
+        actually accepts are forwarded, so the runner can pass extra context
+        (e.g. ``timer``) without every implementation having to declare it.
+        """
+        self.timer = auxiliary_kwargs.get("timer") or Timer()
+        signature = inspect.signature(implementation)
+        accepts_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in signature.parameters.values()
+        )
+        # Forward the same timer instance so any sub-steps an implementation
+        # times nest under the workflow's own timing node.
+        forwarded = {**auxiliary_kwargs, "timer": self.timer}
+        if not accepts_var_keyword:
+            forwarded = {
+                k: v for k, v in forwarded.items() if k in signature.parameters
+            }
+        with self.timer(self.Meta.name):
+            return implementation(analysis, **forwarded)
+
     def eval(self, analysis, **auxiliary_kwargs):
         if analysis.subject is None and analysis.surfaces.exists():
             return self.eval_surfaces(analysis, **auxiliary_kwargs)
         implementation = self.get_implementation(analysis.subject.__class__)
-        result = implementation(analysis, **auxiliary_kwargs)
+        result = self._run_implementation(implementation, analysis, auxiliary_kwargs)
         if result is not None:
             warnings.warn(
                 f"Workflow implementation '{self.Meta.name}' returned a result of type {type(result)}. "
@@ -210,7 +239,7 @@ class WorkflowImplementation:
         else:
             raise ValueError("No surfaces in analysis")
 
-        result = impl(analysis, **auxiliary_kwargs)
+        result = self._run_implementation(impl, analysis, auxiliary_kwargs)
         if result is not None:
             warnings.warn(
                 f"Workflow implementation '{self.Meta.name}' returned a result of type {type(result)}. "

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -7,6 +7,7 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
+from muTimer import Timer
 from SurfaceTopography.Support import doi
 
 from ..manager.models import Surface, Tag, Topography
@@ -15,7 +16,6 @@ from ..taskapp.celeryapp import app
 from ..taskapp.models import Configuration
 from ..taskapp.tasks import ProgressRecorder
 from ..taskapp.utils import get_package_version
-from ..utils.timer import Timer
 from .workflows import WorkflowDefinition
 
 _log = get_task_logger(__name__)


### PR DESCRIPTION
## Problem

Running any workflow crashed with:

```
topography_implementation() got an unexpected keyword argument 'timer'
```

The task runner (`analysis/tasks.py`) creates a `muTimer.Timer` and passes it
through `eval_self` → `Workflow.eval` → `WorkflowImplementation.eval`, which
forwarded it verbatim to the implementation methods. Those methods
(`topography_implementation`, `surface_implementation`, …) don't declare a
`timer` parameter, so the call raised `TypeError`.

## Fix

`WorkflowImplementation._run_implementation` (new helper used by both `eval`
and `eval_surfaces`):

- Forwards only the keyword arguments the implementation actually accepts
  (implementations taking `**kwargs` still receive everything), so the runner
  can pass extra context without every implementation having to declare it.
  This removes the crash.
- Wraps the implementation call in `with self.timer(self.Meta.name)`, so **every
  workflow produces a top-level timing node named after itself** — timing
  information is always produced, even for implementations that don't
  instrument themselves.
- Exposes the same timer as `self.timer` and forwards it as `timer=` to
  implementations that accept it, so their own sub-step timings
  (`with timer("step"): …`) nest under the workflow node.

The analysis path now uses `muTimer.Timer` (matching the base `TaskStateModel`
and the test workflows) so `task_timer` has a consistent hierarchical shape.

## Tests

Added `test_workflow_produces_timing_information`, which runs a workflow
end-to-end and asserts `task_timer` contains the workflow node with its
implementation's nested sub-steps. Full `tests/analysis` + `tests/taskapp`
suites pass (165 passed, 1 skipped).

Follow-ups (separate PRs) add `with timer(...)` sub-step instrumentation to the
statistics and contact plugin workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)