### PR TITLE
BUG: Do not build subject URLs in analysis workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for *TopoBank*
 
+# 1.69.1 (2026-07-21)
+
+- BUG: Do not build subject URLs in analysis workers; `make_alert_entry` no longer requires a subject URL
+
 # 1.69.0 (2026-07-20)
 
 - ENH: Option to reject files with incomplete metadata (`TOPOBANK_REJECT_INCOMPLETE_METADATA`)

--- a/topobank/analysis/legacy/workflows.py
+++ b/topobank/analysis/legacy/workflows.py
@@ -121,7 +121,9 @@ def wrap_series(series, primary_key="x"):
     return wrapped_series
 
 
-def make_alert_entry(level, subject_name, subject_url, data_series_name, detail_mesg):
+def make_alert_entry(
+    level, subject_name, data_series_name, detail_mesg, subject_url=None
+):
     """Build string with alert message often used in the functions.
 
     Parameters
@@ -130,19 +132,24 @@ def make_alert_entry(level, subject_name, subject_url, data_series_name, detail_
         One of ['info', 'warning', 'danger'], see also alert classes in bootstrap 4
     subject_name: str
         Name of the subject.
-    subject_url: str
-        URL of the subject
     data_series_name: str
         Name of the data series this applies to.
     detail_mesg: str
         Details about the alert.
+    subject_url: str, optional
+        URL of the subject. When given, the subject name is rendered as a link;
+        otherwise the plain name is used. Analysis workers no longer build routed
+        URLs (core is REST/UI-agnostic), so this is left unset there.
 
     Returns
     -------
     str
     """
-    link = f'<a class="alert-link" href="{subject_url}">{subject_name}</a>'
-    message = f"Failure for digital surface twin {link}, data series '{data_series_name}': {detail_mesg}"
+    if subject_url:
+        subject = f'<a class="alert-link" href="{subject_url}">{subject_name}</a>'
+    else:
+        subject = subject_name
+    message = f"Failure for digital surface twin {subject}, data series '{data_series_name}': {detail_mesg}"
     return dict(alert_class=f"alert-{level}", message=message)
 
 

--- a/topobank/testing/utils.py
+++ b/topobank/testing/utils.py
@@ -224,9 +224,6 @@ class FakeTopographyModel:
         """Return low level topography."""
         return self.t
 
-    def get_absolute_url(self):
-        return "some/url/"
-
 
 class AnalysisResultMock:
     subject: Union[Tag, Surface, Topography] = None


### PR DESCRIPTION
## Problem

Every statistics analysis (PSD / ACF / variable-bandwidth / scale-dependent) and
the contact-mechanics periodicity warning crash at runtime with:

```
AttributeError: 'Topography' object has no attribute 'get_absolute_url'
```

The "split topobank" refactor made core REST- and UI-agnostic and removed
`get_absolute_url()` from the `Topography`/`Surface`/`Tag` models, but the alert
helper `make_alert_entry` still hard-required a `subject_url`, and the plugin
workers still called `subject.get_absolute_url()` to supply it.

## Change (core side)

- `make_alert_entry`: `subject_url` is now optional. When absent, the subject
  name is rendered as plain text instead of an `<a href>`. Analysis workers no
  longer build routed URLs — that would re-introduce the REST/UI coupling the
  split removed, and these alerts are not delivered to the UI as clickable links
  anyway (`AnalysisCard.vue` renders them as text).
- Removed the dead `FakeTopographyModel.get_absolute_url` test stub in
  `topobank/testing/utils.py`. It returned `"some/url/"` and masked the missing
  method in plugin tests; removing it makes the test subject match the production
  model so this regression is now caught by the suites.

## Companion PRs

The plugin call sites are removed in ContactEngineering/topobank-statistics and
ContactEngineering/topobank-contact.

## Verification

`tests/analysis` passes (111 passed, 1 skipped). With the stub removed, the
statistics (30) and contact (11) suites pass while exercising the production
path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)