### PR TITLE
MAINT: Replaced `tracemalloc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for *TopoBank*
 
+# 1.69.2 (2026-07-22)
+
+- PERF: `task_memory` now records per-task peak RSS (resettable `VmHWM`) instead of
+  `tracemalloc`, which slowed numpy-heavy tasks ~35x; tracemalloc is opt-in via `TOPOBANK_TRACK_MEMORY_USAGE`
+- BUG: Memory tracing was never stopped when a task raised, leaving `tracemalloc`
+  enabled for all subsequent tasks in the same worker process
+
 # 1.69.1 (2026-07-21)
 
 - BUG: Do not build subject URLs in analysis workers; `make_alert_entry` no longer requires a subject URL

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -340,7 +340,16 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         """
         self.fix_folder()
         if self._result_cache is None:
-            self._result_cache = load_split_dict(self.folder, RESULT_FILE_BASENAME)
+            try:
+                self._result_cache = load_split_dict(
+                    self.folder, RESULT_FILE_BASENAME
+                )
+            except FileNotFoundError:
+                # Artifact-only workflows (e.g. the v3 map tasks) return None
+                # from their implementation, so no result.json is stored —
+                # honor the documented "None if there is nothing yet" contract
+                # instead of leaking the storage lookup failure.
+                return None
         return self._result_cache
 
     @property

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -1,6 +1,5 @@
 import json
 import traceback
-import tracemalloc
 from typing import Any, Dict
 
 import celery
@@ -15,6 +14,7 @@ from ..manager.models import Surface, Tag, Topography
 from ..supplib.db import advisory_lock
 from ..supplib.dict import store_split_dict
 from ..taskapp.celeryapp import app
+from ..taskapp.memory import track_memory_usage
 from ..taskapp.models import Configuration
 from ..taskapp.tasks import ProgressRecorder
 from ..taskapp.utils import get_package_version
@@ -437,8 +437,6 @@ def execute_workflow(
     )
     try:
         dois = set()
-        tracemalloc.start()
-        tracemalloc.reset_peak()
         timer = Timer(str(self.request.id))
         on_progress = None
         # If a callback is configured, create a progress callback.
@@ -463,16 +461,22 @@ def execute_workflow(
                 },
             )
 
-        result = evaluate_function(
-            dois=dois,
-            progress_recorder=ProgressRecorder(self, on_progress=on_progress),
-            timer=timer,
-            finished_analyses=finished_dependencies,
-        )
-        size, peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        # Peak-memory tracking: cheap RSS high-water mark by default;
+        # precise (but ~35x slower on numeric workloads) tracemalloc only
+        # when TOPOBANK_TRACK_MEMORY_USAGE is enabled. See taskapp/memory.py.
+        with track_memory_usage() as memory_usage:
+            result = evaluate_function(
+                dois=dois,
+                progress_recorder=ProgressRecorder(self, on_progress=on_progress),
+                timer=timer,
+                finished_analyses=finished_dependencies,
+            )
         save_result(
-            result, WorkflowResult.SUCCESS, peak_memory=peak, dois=dois, timer=timer
+            result,
+            WorkflowResult.SUCCESS,
+            peak_memory=memory_usage.peak,
+            dois=dois,
+            timer=timer,
         )
     except Exception as exc:
         _log.exception(

--- a/topobank/taskapp/memory.py
+++ b/topobank/taskapp/memory.py
@@ -1,0 +1,166 @@
+"""Peak-memory tracking for task execution.
+
+Every workflow / task-model run records its peak memory into ``task_memory``,
+which is used to right-size workers. Two facts drive the design:
+
+1. ``tracemalloc`` is the wrong tool for sizing. It traces *Python-allocator*
+   bytes only — it misses native allocations (SDSAlgorithms/Eigen C++, NetCDF
+   buffers), allocator fragmentation and the interpreter/Django baseline, all
+   of which the OOM killer and container limits very much count. And numpy
+   reports every array-data allocation to it: measured overhead on an
+   allocation-heavy 20-Mpx feature computation is ~35x wall clock
+   (28 s → 16 min). It stays available, opt-in, for *leak hunting and
+   allocation attribution* via ``settings.TOPOBANK_TRACK_MEMORY_USAGE = True``
+   — a different question from sizing.
+
+2. The kernel already keeps the number sizing needs. ``VmHWM`` in
+   ``/proc/self/status`` is the process's peak RSS, and writing ``"5"`` to
+   ``/proc/self/clear_refs`` resets it to the *current* RSS. Reset on task
+   start, read on task end → true per-task peak RSS at the cost of two /proc
+   accesses. Celery's prefork children execute one task at a time, so
+   per-process is per-task. (With a threaded/gevent pool concurrent tasks
+   would share the counter — the value then over-approximates, which for
+   sizing is the safe direction.)
+
+Fallback ladder when ``clear_refs`` is unavailable (non-Linux dev machines,
+hardened containers): a background thread samples ``/proc/self/statm`` every
+100 ms for the task's duration (misses only sub-100-ms spikes); if /proc is
+unavailable entirely, ``getrusage(ru_maxrss)`` — a process-lifetime
+high-water mark, i.e. an upper bound in reused workers.
+
+For capacity planning: a worker needs roughly
+``parent + concurrency x max(task_memory)`` — task peaks here already
+include the per-child interpreter/Django baseline.
+"""
+
+import resource
+import sys
+import threading
+import tracemalloc
+from contextlib import contextmanager
+
+from django.conf import settings
+
+_PAGE_SIZE = resource.getpagesize()
+
+#: Sampling interval of the fallback RSS sampler thread.
+_SAMPLE_INTERVAL = 0.1  # seconds
+
+
+def _read_vm_hwm():
+    """Peak RSS (``VmHWM``) of this process in bytes, or ``None``."""
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmHWM:"):
+                    return int(line.split()[1]) * 1024  # kB → bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _reset_vm_hwm():
+    """Reset this process's peak-RSS counter to its current RSS.
+
+    Returns True on success. Writing "5" to ``/proc/self/clear_refs`` is the
+    documented kernel interface for resetting ``VmHWM`` (see proc(5)).
+    """
+    try:
+        with open("/proc/self/clear_refs", "w") as f:
+            f.write("5")
+        return True
+    except OSError:
+        return False
+
+
+def _read_rss():
+    """Current RSS in bytes via ``/proc/self/statm``, or ``None``."""
+    try:
+        with open("/proc/self/statm") as f:
+            return int(f.read().split()[1]) * _PAGE_SIZE
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+class _RssSampler:
+    """Background thread recording the max RSS observed during a block."""
+
+    def __init__(self):
+        self.peak = _read_rss() or 0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="rss-sampler", daemon=True
+        )
+
+    def _run(self):
+        while not self._stop.wait(_SAMPLE_INTERVAL):
+            rss = _read_rss()
+            if rss is not None and rss > self.peak:
+                self.peak = rss
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        rss = _read_rss()
+        if rss is not None and rss > self.peak:
+            self.peak = rss
+
+
+class MemoryUsage:
+    """Result object filled in when the ``track_memory_usage`` block exits."""
+
+    #: Peak memory in bytes. Default modes report peak RSS (what the OOM
+    #: killer / container limits act on); the opt-in tracemalloc mode reports
+    #: peak Python-allocator usage instead. ``None`` until the block exits.
+    peak = None
+
+
+@contextmanager
+def track_memory_usage():
+    """Context manager yielding a :class:`MemoryUsage` whose ``peak`` is set
+    on exit (including the exception path — the previous inline tracemalloc
+    calls skipped ``stop()`` on failure, leaving tracing enabled for every
+    subsequent task in the worker process)."""
+    usage = MemoryUsage()
+
+    if getattr(settings, "TOPOBANK_TRACK_MEMORY_USAGE", False):
+        # Opt-in allocation profiling (leak hunting) — NOT for sizing; ~35x
+        # slower on numeric workloads and blind to native allocations.
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        try:
+            yield usage
+        finally:
+            _, usage.peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+        return
+
+    if _reset_vm_hwm():
+        # Preferred: kernel-maintained per-task peak RSS, ~zero overhead.
+        try:
+            yield usage
+        finally:
+            usage.peak = _read_vm_hwm()
+        return
+
+    if _read_rss() is not None:
+        # /proc exists but the peak counter can't be reset: sample RSS.
+        with _RssSampler() as sampler:
+            try:
+                yield usage
+            finally:
+                usage.peak = sampler.peak
+        return
+
+    # Last resort (no /proc, i.e. macOS dev machines): process-lifetime
+    # high-water mark — an upper bound for the current task in reused
+    # workers. ru_maxrss is KiB on Linux, bytes on macOS.
+    scale = 1 if sys.platform == "darwin" else 1024
+    try:
+        yield usage
+    finally:
+        usage.peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale

--- a/topobank/taskapp/models.py
+++ b/topobank/taskapp/models.py
@@ -1,7 +1,6 @@
 import inspect
 import logging
 import traceback
-import tracemalloc
 from decimal import Decimal
 
 import celery.states
@@ -13,6 +12,7 @@ from muTimer import Timer
 from SurfaceTopography.Exceptions import CannotDetectFileFormat
 
 from .celeryapp import app
+from .memory import track_memory_usage
 from .tasks import ProgressRecorder
 
 _log = logging.getLogger(__name__)
@@ -498,20 +498,20 @@ class TaskStateModel(models.Model):
 
         # actually run the task
         try:
-            tracemalloc.start()
-            tracemalloc.reset_peak()
-            # Check if task_worker accepts timer argument
-            sig = inspect.signature(self.task_worker)
-            if 'timer' in sig.parameters:
-                timer = Timer(str(self.task_id))
-                self.task_worker(*args, timer=timer, **kwargs)
-                self.task_timer = timer.to_dict()
-            else:
-                self.task_worker(*args, **kwargs)
-            size, peak = tracemalloc.get_traced_memory()
-            tracemalloc.stop()
+            # Peak-memory tracking: cheap RSS high-water mark by default;
+            # precise (but ~35x slower on numeric workloads) tracemalloc only
+            # when TOPOBANK_TRACK_MEMORY_USAGE is enabled. See taskapp/memory.py.
+            with track_memory_usage() as memory_usage:
+                # Check if task_worker accepts timer argument
+                sig = inspect.signature(self.task_worker)
+                if 'timer' in sig.parameters:
+                    timer = Timer(str(self.task_id))
+                    self.task_worker(*args, timer=timer, **kwargs)
+                    self.task_timer = timer.to_dict()
+                else:
+                    self.task_worker(*args, **kwargs)
             self.task_state = TaskStateModel.SUCCESS
-            self.task_memory = peak
+            self.task_memory = memory_usage.peak
             self.task_error = ""
         except CannotDetectFileFormat:
             self.task_state = TaskStateModel.FAILURE


### PR DESCRIPTION
- PERF: `task_memory` now records per-task peak RSS (resettable `VmHWM`) instead of
  `tracemalloc`, which slowed numpy-heavy tasks ~35x; tracemalloc is opt-in via `TOPOBANK_TRACK_MEMORY_USAGE`
- BUG: Memory tracing was never stopped when a task raised, leaving `tracemalloc`
  enabled for all subsequent tasks in the same worker process
