### PR TITLE
BUG: Persist timer on task failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for *TopoBank*
 
+# 1.69.3 (2026-07-23)
+
+- ENH: Persist per-stage task timing (`task_timer`) when a workflow fails —
+  previously only successful runs recorded it, so timeouts (e.g.
+  `SoftTimeLimitExceeded`) left no way to tell which stage consumed the budget
+
 # 1.69.2 (2026-07-22)
 
 - PERF: `task_memory` now records per-task peak RSS (resettable `VmHWM`) instead of

--- a/tests/analysis/test_tasks.py
+++ b/tests/analysis/test_tasks.py
@@ -180,6 +180,30 @@ def test_workflow_produces_timing_information(two_topos, test_workflow):
     assert {"save_file1", "save_file2"} <= child_names
 
 
+@pytest.mark.django_db
+def test_failed_workflow_persists_timing_information(two_topos, test_workflow):
+    """Timings recorded before a failure must survive it.
+
+    A timed-out or crashed run previously lost its timer (only ``save_result``
+    persisted it, and that never runs on failure), so a SoftTimeLimitExceeded
+    gave no way to tell "one stage stalled for an hour" from "many stages,
+    each fast, exceeded the budget together". The runner wraps every
+    implementation in a workflow-named timing node (recorded in a ``finally``),
+    so even a workflow failing mid-flight leaves its partial duration behind —
+    and the failure path must persist it.
+    """
+    topo = Topography.objects.first()
+    analysis = _pending_analysis(topo, "topobank.testing.test_error")
+
+    perform_analysis.apply(args=(analysis.id, True))
+
+    analysis.refresh_from_db()
+    assert analysis.task_state == WorkflowResult.FAILURE
+    assert analysis.task_timer is not None
+    names = {t["name"] for t in analysis.task_timer["timers"]}
+    assert "topobank.testing.test_error" in names
+
+
 # ---------------------------------------------------------------------------
 # Dependency FAILURE propagation (regression: parent must not hang)
 # ---------------------------------------------------------------------------

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -435,9 +435,13 @@ def execute_workflow(
     _log.debug(
         f"{analysis_id}/{self.request.id}: Starting evaluation of analysis function..."
     )
+    # Created outside the try so the failure path below can persist whatever
+    # block durations were recorded before the exception (Timer records in a
+    # finally, so an interrupted block — e.g. a SoftTimeLimitExceeded mid
+    # LOO fold — still leaves its partial duration behind).
+    timer = Timer(str(self.request.id))
     try:
         dois = set()
-        timer = Timer(str(self.request.id))
         on_progress = None
         # If a callback is configured, create a progress callback.
         callback_path = getattr(settings, "WORKFLOW_PROGRESS_CALLBACK", None)
@@ -485,6 +489,13 @@ def execute_workflow(
         analysis.task_state = WorkflowResult.FAILURE
         analysis.task_traceback = traceback.format_exc().replace("\x00", "")
         analysis.task_error = str(exc).replace("\x00", "")
+        # Persist the timings recorded up to the failure: for timeouts this is
+        # what distinguishes "one stage stalled for an hour" from "many stages,
+        # each fast, exceeded the budget together". muTimer records in a
+        # finally, so the interrupted block carries its partial duration.
+        timer_dict = timer.to_dict()
+        if timer_dict.get("timers"):
+            analysis.task_timer = timer_dict
         analysis.save()
         # Propagate the failure to the parent when this ran as a dependency.
         #


### PR DESCRIPTION
This PR enables timing record even if a task fails. This allows inspection of timing of partially completed task, important if the task hits some timeout.