### PR TITLE
ENH: Allow settings to define time limits for tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 # 1.69.3 (2026-07-24)
 
 - ENH: Workflow task time limits are read from the `CELERY_TASK_SOFT_TIME_LIMIT` /
-  `CELERY_TASK_TIME_LIMIT` settings (falling back to a 6-hour hard limit) instead
-  of a hardcoded one hour, so long-running workflows such as model training can
-  complete
+  `CELERY_TASK_TIME_LIMIT` settings (falling back to a 6-hour hard limit)
 - ENH: Persist per-stage task timing (`task_timer`) when a workflow fails —
   previously only successful runs recorded it, so timeouts (e.g.
   `SoftTimeLimitExceeded`) left no way to tell which stage consumed the budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog for *TopoBank*
 
-# 1.69.3 (2026-07-23)
+# 1.69.3 (2026-07-24)
 
+- ENH: Workflow task time limits are read from the `CELERY_TASK_SOFT_TIME_LIMIT` /
+  `CELERY_TASK_TIME_LIMIT` settings (falling back to a 6-hour hard limit) instead
+  of a hardcoded one hour, so long-running workflows such as model training can
+  complete
 - ENH: Persist per-stage task timing (`task_timer`) when a workflow fails —
   previously only successful runs recorded it, so timeouts (e.g.
   `SoftTimeLimitExceeded`) left no way to tell which stage consumed the budget

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 import celery
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.utils import timezone
 from muTimer import Timer
@@ -21,6 +22,23 @@ from ..taskapp.utils import get_package_version
 from .workflows import WorkflowDefinition
 
 _log = get_task_logger(__name__)
+
+# Time limits for the workflow tasks below. Long-running workflows (e.g. model
+# training) can exceed a fixed one-hour budget, so the limits are taken from
+# the standard Celery settings where deployments tune them. Falls back to a
+# 6-hour hard limit (soft limit 5 minutes earlier for graceful cleanup) when
+# the settings are absent or Django settings are not configured.
+DEFAULT_TASK_TIME_LIMIT = 21600  # 6 hours
+DEFAULT_TASK_SOFT_TIME_LIMIT = DEFAULT_TASK_TIME_LIMIT - 300
+
+try:
+    TASK_SOFT_TIME_LIMIT = getattr(
+        settings, "CELERY_TASK_SOFT_TIME_LIMIT", DEFAULT_TASK_SOFT_TIME_LIMIT
+    )
+    TASK_TIME_LIMIT = getattr(settings, "CELERY_TASK_TIME_LIMIT", DEFAULT_TASK_TIME_LIMIT)
+except ImproperlyConfigured:
+    TASK_SOFT_TIME_LIMIT = DEFAULT_TASK_SOFT_TIME_LIMIT
+    TASK_TIME_LIMIT = DEFAULT_TASK_TIME_LIMIT
 
 
 def get_current_configuration():
@@ -64,7 +82,7 @@ def get_current_configuration():
             return make_config_from_versions()
 
 
-@app.task(bind=True, soft_time_limit=3600, time_limit=3700)
+@app.task(bind=True, soft_time_limit=TASK_SOFT_TIME_LIMIT, time_limit=TASK_TIME_LIMIT)
 def schedule_workflow(
     self: celery.Task,
     analysis_id: int,
@@ -279,7 +297,7 @@ def _fail_parent_on_dependency_failure(parent_id, dependency, request_id):
         )
 
 
-@app.task(bind=True, soft_time_limit=3600, time_limit=3700)
+@app.task(bind=True, soft_time_limit=TASK_SOFT_TIME_LIMIT, time_limit=TASK_TIME_LIMIT)
 def execute_workflow(
     self: celery.Task,
     analysis_id: int,
@@ -525,7 +543,7 @@ def execute_workflow(
 
 
 # Keep perform_analysis as an alias for backward compatibility
-@app.task(bind=True, soft_time_limit=3600, time_limit=3700)
+@app.task(bind=True, soft_time_limit=TASK_SOFT_TIME_LIMIT, time_limit=TASK_TIME_LIMIT)
 def perform_analysis(self: celery.Task, analysis_id: int, force: bool):
     """Perform an analysis which is already present in the database.
 


### PR DESCRIPTION
## Summary

The workflow tasks in `topobank/analysis/tasks.py` (`schedule_workflow`, `execute_workflow`, `perform_analysis`) hardcoded `soft_time_limit=3600, time_limit=3700` in their decorators. Because per-task decorator options take precedence over Celery's global configuration, deployments could not raise the limit for long-running workflows (e.g. model training pipelines), which failed with `SoftTimeLimitExceeded` after one hour regardless of the `CELERY_TASK_SOFT_TIME_LIMIT` / `CELERY_TASK_TIME_LIMIT` settings.

The task decorators now read the standard Celery settings `CELERY_TASK_SOFT_TIME_LIMIT` and `CELERY_TASK_TIME_LIMIT` from Django settings at import time. When the settings are absent (or Django settings are not configured), they fall back to a 6-hour hard limit with the soft limit five minutes earlier for graceful cleanup.

## Behavior change

Deployments that do not define these settings move from a 1-hour to a 6-hour default limit for these tasks; deployments that do define them get exactly what they configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)