### PR TITLE
MAINT: Removed unused --changelog option from notify_users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for *TopoBank*
 
-# 1.70.0 (2026-07-31)
+# 1.70.0 (2026-08-02)
 
 - ENH: Full text search index
 - ENH: Asynchronous creation of ZIP archives for downloads
@@ -11,6 +11,8 @@
 - MAINT: Use matplotlib's OO API for rendering thumbnail of line scans
 - MAINT: New `to_natural_length_unit` helper that converts physical sizes to the
   most natural length unit for display and editing
+- MAINT: Removed the unused `--changelog` option from the `notify_users` command
+  of the testing mock-auth app; it was accepted but had no effect
 
 # 1.69.4 (2026-07-25)
 

--- a/topobank/testing/mock_auth/users/management/commands/notify_users.py
+++ b/topobank/testing/mock_auth/users/management/commands/notify_users.py
@@ -27,12 +27,6 @@ class Command(BaseCommand):
             dest='recipient',
             help='Username of the user who is the recipient. If not given, send to all users.',
         )
-        parser.add_argument(
-            '--changelog',
-            action='store_true',
-            dest='changelog',
-            help='Clicking the notification links to the current Changelog file. Default is a link to home.',
-        )
 
     def handle(self, *args, **options):
         User = get_user_model()


### PR DESCRIPTION
## Summary

The `--changelog` option of the `notify_users` management command in the testing mock-auth app was declared but never read — `href` was set to `'#'` regardless of the flag. Its help text ("Clicking the notification links to the current Changelog file") therefore did not describe actual behaviour.

The changelog is no longer shipped to users at all: the component versions in the ce-ui side panel link to the respective repositories, where the changelogs are published. The equivalent option is removed from the real command in ContactEngineering/topobank-orcid.

## Changelog

`1.70.0` is not yet tagged, so this amends the existing entry rather than adding a new version, and moves its date to today.

## Testing

- `tests/users/test_commands.py::test_notify` passes — it calls `notify_users "Hey there"` with no flags
- flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)