### PR TITLE
BUG: Fixed duplicate Version rows failing every analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for *TopoBank*
 
+# 1.70.1 (2026-08-02)
+
+- BUG: Every analysis failed with `get() returned more than one Version` once two
+  workers had concurrently registered the same dependency version. `Version` was
+  guarded by a `unique_together` over nullable `micro`/`extra` columns, and
+  PostgreSQL treats NULLs as distinct in a UNIQUE constraint, so the guard never
+  applied to ordinary release numbers (`1.70.0` parses to `extra=None`)
+- MAINT: `Version` uniqueness is now a `UniqueConstraint` with
+  `nulls_distinct=False` (requires PostgreSQL 15+); a data migration merges
+  pre-existing duplicates and repoints `Configuration.versions` at the surviving
+  rows
+- MAINT: `get_package_version` tolerates duplicate `Version` rows left behind by
+  older databases instead of failing the task
+
 # 1.70.0 (2026-08-02)
 
 - ENH: Full text search index

--- a/tests/taskapp/test_version_uniqueness.py
+++ b/tests/taskapp/test_version_uniqueness.py
@@ -41,10 +41,23 @@ def test_duplicate_version_rejected_including_null_columns(micro, extra):
 
 @pytest.mark.django_db
 def test_get_package_version_survives_preexisting_duplicates():
-    # Simulate a database written before the constraint was fixed by inserting
-    # a duplicate behind the ORM's back.
+    if connection.vendor != "postgresql":
+        pytest.skip("needs PostgreSQL to drop and re-create the constraint")
+
     version = get_package_version("numpy", repr("1.70.0"))
     with connection.cursor() as cursor:
+        # Simulate a database that has not run taskapp migration 0003 yet. The
+        # constraint is precisely what makes duplicates impossible, so it has to
+        # come off before the legacy state can be reproduced. PostgreSQL DDL is
+        # transactional, so the test's transaction rolls this back.
+        #
+        # The row created above leaves deferred foreign-key trigger events
+        # queued, and PostgreSQL refuses to ALTER TABLE while they are pending.
+        cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+        cursor.execute(
+            "ALTER TABLE taskapp_version "
+            "DROP CONSTRAINT unique_version_per_dependency"
+        )
         cursor.execute(
             "INSERT INTO taskapp_version (dependency_id, major, minor, micro, extra) "
             "VALUES (%s, %s, %s, %s, %s)",

--- a/tests/taskapp/test_version_uniqueness.py
+++ b/tests/taskapp/test_version_uniqueness.py
@@ -1,0 +1,87 @@
+"""Duplicate `Version` rows must be impossible, and survivable if present.
+
+A clean release string such as "1.70.0" parses to ``extra=None``, and pre-1.70
+releases also leave ``micro=None``. The old ``unique_together`` therefore
+covered columns that are NULL in the common case, and PostgreSQL treats NULLs
+as distinct in a UNIQUE constraint -- so nothing stopped two concurrent
+``get_or_create()`` calls from inserting the same version twice. Once that
+happened, the ``get()`` inside ``get_or_create()`` raised
+``MultipleObjectsReturned`` and every analysis failed.
+"""
+
+import threading
+
+import pytest
+from django.db import IntegrityError, connection, transaction
+
+from topobank.taskapp.models import Dependency, Version
+from topobank.taskapp.utils import get_package_version
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "micro,extra",
+    [
+        (None, None),  # e.g. "1.70"
+        (0, None),  # e.g. "1.70.0" -- the common release case
+        (None, "rc1"),
+        (0, "rc1"),
+    ],
+)
+def test_duplicate_version_rejected_including_null_columns(micro, extra):
+    dep = Dependency.objects.create(import_name="somepackage")
+    Version.objects.create(dependency=dep, major=1, minor=70, micro=micro, extra=extra)
+
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Version.objects.create(
+                dependency=dep, major=1, minor=70, micro=micro, extra=extra
+            )
+
+
+@pytest.mark.django_db
+def test_get_package_version_survives_preexisting_duplicates():
+    # Simulate a database written before the constraint was fixed by inserting
+    # a duplicate behind the ORM's back.
+    version = get_package_version("numpy", repr("1.70.0"))
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO taskapp_version (dependency_id, major, minor, micro, extra) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            [version.dependency_id, 1, 70, 0, None],
+        )
+
+    assert (
+        Version.objects.filter(dependency=version.dependency, major=1, minor=70).count()
+        == 2
+    )
+
+    # Must not raise MultipleObjectsReturned, and must settle on the older row.
+    assert get_package_version("numpy", repr("1.70.0")).id == version.id
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_get_package_version_creates_single_row():
+    if connection.vendor != "postgresql":
+        pytest.skip("relies on PostgreSQL constraint semantics")
+
+    barrier = threading.Barrier(4)
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=10)
+            get_package_version("numpy", repr("9.9.9"))
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+        finally:
+            connection.close()
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    assert Version.objects.filter(major=9, minor=9, micro=9).count() == 1

--- a/topobank/taskapp/migrations/0003_dedupe_version_unique_nulls_not_distinct.py
+++ b/topobank/taskapp/migrations/0003_dedupe_version_unique_nulls_not_distinct.py
@@ -1,0 +1,93 @@
+"""Remove duplicate `Version` rows and enforce uniqueness including NULLs.
+
+`Version` had `unique_together = (("dependency", "major", "minor", "micro",
+"extra"),)`, but `micro` and `extra` are nullable and are NULL for most
+releases. PostgreSQL treats NULLs as distinct in a UNIQUE constraint, so the
+constraint never fired for the common case and concurrent
+`Version.objects.get_or_create()` calls (one per tracked dependency, on every
+analysis) could insert duplicates.
+
+Once duplicated, the `get()` inside `get_or_create()` raises
+`MultipleObjectsReturned` and *every* analysis fails until the rows are cleaned
+up. This migration merges the duplicates and replaces the constraint with one
+that compares NULLs as equal.
+"""
+
+from django.db import migrations, models
+
+
+def dedupe_versions(apps, schema_editor):
+    Version = apps.get_model("taskapp", "Version")
+    Configuration = apps.get_model("taskapp", "Configuration")
+    Through = Configuration.versions.through
+
+    # Keep the oldest row of each duplicate group so that existing references
+    # point at the survivor whenever possible.
+    keep_by_key = {}
+    duplicates = {}  # duplicate id -> id of the row it is merged into
+    for version_id, dependency_id, major, minor, micro, extra in (
+        Version.objects.order_by("id").values_list(
+            "id", "dependency_id", "major", "minor", "micro", "extra"
+        )
+    ):
+        key = (dependency_id, major, minor, micro, extra)
+        if key in keep_by_key:
+            duplicates[version_id] = keep_by_key[key]
+        else:
+            keep_by_key[key] = version_id
+
+    if not duplicates:
+        return
+
+    # Repoint Configuration.versions at the surviving rows. Deleting the
+    # duplicates directly would cascade away these links and silently strip
+    # dependencies from historical configurations.
+    for duplicate_id, keep_id in duplicates.items():
+        for link_id, configuration_id in Through.objects.filter(
+            version_id=duplicate_id
+        ).values_list("id", "configuration_id"):
+            if Through.objects.filter(
+                configuration_id=configuration_id, version_id=keep_id
+            ).exists():
+                # The configuration already references the survivor; the link
+                # via the duplicate is redundant.
+                Through.objects.filter(id=link_id).delete()
+            else:
+                Through.objects.filter(id=link_id).update(version_id=keep_id)
+
+    Version.objects.filter(id__in=list(duplicates)).delete()
+
+    if schema_editor.connection.vendor == "postgresql":
+        # Django declares foreign keys DEFERRABLE INITIALLY DEFERRED, so the
+        # writes above leave trigger events queued and PostgreSQL then refuses
+        # to ALTER TABLE ("pending trigger events"). Force the checks to happen
+        # now so that AddConstraint can run in this same transaction -- keeping
+        # both in one transaction is what guarantees there is no window in
+        # which a concurrent worker could insert a fresh duplicate between the
+        # de-duplication and the constraint taking effect.
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("taskapp", "0002_alter_configuration_table_alter_dependency_table_and_more"),
+    ]
+
+    operations = [
+        # Drop the old constraint first: the de-duplication below has to run
+        # before the stricter constraint is added, and the two cannot coexist.
+        migrations.AlterUniqueTogether(
+            name="version",
+            unique_together=set(),
+        ),
+        migrations.RunPython(dedupe_versions, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="version",
+            constraint=models.UniqueConstraint(
+                fields=["dependency", "major", "minor", "micro", "extra"],
+                name="unique_version_per_dependency",
+                nulls_distinct=False,
+            ),
+        ),
+    ]

--- a/topobank/taskapp/models.py
+++ b/topobank/taskapp/models.py
@@ -563,7 +563,22 @@ class Version(models.Model):
     """
 
     class Meta:
-        unique_together = (("dependency", "major", "minor", "micro", "extra"),)
+        constraints = [
+            # `micro` and `extra` are nullable and are NULL for most releases
+            # (a clean "1.70.0" parses to extra=None). A plain `unique_together`
+            # maps to a UNIQUE constraint, and PostgreSQL treats NULLs as
+            # distinct there, so it did *not* prevent duplicate rows for exactly
+            # the common case. Two workers calling `get_or_create()` for a
+            # freshly deployed version could therefore both insert, and every
+            # later `get_or_create()` would raise `MultipleObjectsReturned`,
+            # failing every analysis. `nulls_distinct=False` (PostgreSQL 15+)
+            # makes NULL compare equal so the constraint actually holds.
+            models.UniqueConstraint(
+                fields=["dependency", "major", "minor", "micro", "extra"],
+                name="unique_version_per_dependency",
+                nulls_distinct=False,
+            )
+        ]
 
     dependency = models.ForeignKey(Dependency, on_delete=models.CASCADE)
 

--- a/topobank/taskapp/utils.py
+++ b/topobank/taskapp/utils.py
@@ -159,9 +159,35 @@ def get_package_version(pkg_name, version_expr):
     dep, created = Dependency.objects.get_or_create(import_name=pkg_name)
 
     # make sure the current version of the dependency is available in database
-    version, created = Version.objects.get_or_create(
-        dependency=dep, major=major, minor=minor, micro=micro, extra=extra
-    )
+    try:
+        version, created = Version.objects.get_or_create(
+            dependency=dep, major=major, minor=minor, micro=micro, extra=extra
+        )
+    except Version.MultipleObjectsReturned:
+        # Databases written before the unique constraint was fixed can contain
+        # duplicate rows for the same version, because PostgreSQL treated the
+        # NULL `micro`/`extra` of the old `unique_together` as distinct. The
+        # `get()` inside `get_or_create()` then fails and takes every analysis
+        # down with it. Settle on the oldest row so that analyses keep running;
+        # taskapp migration 0003 merges the duplicates away for good.
+        version = (
+            Version.objects.filter(
+                dependency=dep, major=major, minor=minor, micro=micro, extra=extra
+            )
+            .order_by("id")
+            .first()
+        )
+        _log.warning(
+            "Found duplicate Version rows for %s %s.%s (micro=%s, extra=%s); "
+            "using the oldest (id=%s). Run the taskapp migrations to remove the "
+            "duplicates.",
+            pkg_name,
+            major,
+            minor,
+            micro,
+            extra,
+            version.id,
+        )
 
     return version
 


### PR DESCRIPTION
## Problem

On the testing instance every analysis task fails with:

```
get() returned more than one Version -- it returned 2!
```

`get_current_configuration()` runs at the start of every analysis
(`topobank/analysis/tasks.py:172,374`) and calls `get_package_version()` once per
tracked dependency, which does `Version.objects.get_or_create(...)`. `get_or_create`
begins with `.get()`, and `.get()` on two matching rows raises `MultipleObjectsReturned`.
`get_or_create` only catches `DoesNotExist` and `IntegrityError`, so it propagates and
kills the task before any analysis work starts — every workflow fails, permanently,
until the rows are cleaned up by hand.

## Why duplicates exist

The uniqueness guard never worked. `unique_together` covered
`("dependency", "major", "minor", "micro", "extra")`, but `micro` and `extra` are
nullable and PostgreSQL treats NULLs as **distinct** in a UNIQUE constraint. An
ordinary release string parses to `extra=None` (`_parse("1.66.3") == (1, 66, 3, None)`,
per `tests/taskapp/test_utils.py`), so the constraint was decorative for the normal case.

Verified against postgres:17.4:

| schema | result for `(1, 1, 70, 0, NULL)` inserted twice |
|---|---|
| `UNIQUE` (before) | 2 rows accepted |
| `UNIQUE NULLS NOT DISTINCT` (after) | second insert rejected |

The trigger is deployment: a version bump creates these rows for the first time and
workers hit that window together. This is the sibling of #1344 (the `Configuration`
race, fixed with an advisory lock); the `Version` layer underneath it never got one.

## Fix

- `Version.Meta` now uses `UniqueConstraint(..., nulls_distinct=False)`, emitting
  `UNIQUE NULLS NOT DISTINCT`. Requires PostgreSQL 15+ (deployed stack is on 17.4)
  and Django 5.0+ (on 5.2.16).
- Migration `taskapp/0003` merges existing duplicates, then adds the constraint. It
  repoints `Configuration.versions` at the surviving row first — deleting duplicates
  directly would cascade those links away and silently strip dependencies from
  historical configurations. Both steps share one transaction, so there is no window
  for a worker to insert a fresh duplicate mid-migration.
- `get_package_version()` catches `MultipleObjectsReturned` and settles on the oldest
  row with a warning, so an affected instance recovers even before the migration runs.

## Verification

Reproduced the race with 8 concurrent workers against postgres:17.4:

```
BEFORE: 8 rows created, 0 errors → next get_or_create:
        MultipleObjectsReturned: get() returned more than one Version -- it returned 8!
AFTER:  1 row created, 0 errors → next get_or_create: OK
```

The migration was driven end-to-end with duplicates seeded as the race creates them and
three `Configuration`s wired across *different* duplicate rows: duplicates merged,
distinct rows untouched, links repointed at survivors, no `Configuration` left empty,
new duplicates rejected.

That exercise caught a bug in the first draft — the deletes leave deferred FK trigger
events queued, so the follow-on `ALTER TABLE` failed with `cannot ALTER TABLE ... pending
trigger events`. Fixed with `SET CONSTRAINTS ALL IMMEDIATE`.

`flake8` and `isort` are clean on the changed files.

## CI

All checks pass on `postgres:17`, which is the environment that actually exercises
`NULLS NOT DISTINCT`:

```
test_duplicate_version_rejected_including_null_columns[None-None]  PASSED
test_duplicate_version_rejected_including_null_columns[0-None]     PASSED
test_duplicate_version_rejected_including_null_columns[None-rc1]   PASSED
test_duplicate_version_rejected_including_null_columns[0-rc1]      PASSED
test_get_package_version_survives_preexisting_duplicates           PASSED
test_concurrent_get_package_version_creates_single_row             PASSED
```

The first CI run failed on `test_get_package_version_survives_preexisting_duplicates`
— it created its duplicate with raw SQL, which the new constraint (correctly) rejects,
so it failed on its own setup. Commit 3b9e20d4 drops the constraint inside the test
transaction first, which is what a database that has not run migration 0003 actually
looks like; PostgreSQL DDL is transactional so the rollback restores it. Everything
else passed on that first run, including the concurrency test.

## Release note

The changelog adds a `1.70.1 (2026-08-02)` section, but the version itself comes from
the git tag via hatch-vcs — no tag is created here. Tag `1.70.1` on `main` after merge
to make the release real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
