### PR TITLE
ENH: Record the extent of a data series in its metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- ENH: A data series records the extent of its data next to the reference to its
+  file, so a plot can pick a display unit that suits the data without reading the
+  series back out of the object store
+
 - ENH: Measurements record `detrend_parameters`, the trend that detrending
   subtracted: the slope of the removed tilt and the radius of the removed
   curvature, in physical units

--- a/tests/analysis/test_series_metadata.py
+++ b/tests/analysis/test_series_metadata.py
@@ -1,0 +1,91 @@
+"""
+Tests for the metadata that accompanies a split-off data series.
+
+Series data lives in its own file in the object store, so anything a plot needs
+before fetching them has to be recorded next to the reference. That includes the
+extent of the data, which is what lets a plot combining several results choose a
+display unit that suits them (ContactEngineering/ce-ui#39).
+"""
+
+import numpy as np
+
+from topobank.analysis.legacy.workflows import wrap_series
+
+
+def _supplementary(series):
+    """The metadata of each wrapped series, in order."""
+    return [wrapped.supplementary for wrapped in wrap_series(series)]
+
+
+def test_records_the_range_of_both_axes():
+    (metadata,) = _supplementary(
+        [{"name": "Height distribution", "x": [-2.0, 0.5, 3.0], "y": [0.1, 0.9, 0.2]}]
+    )
+    assert metadata["xRange"] == [-2.0, 3.0]
+    assert metadata["yRange"] == [0.1, 0.9]
+
+
+def test_keeps_the_existing_metadata():
+    (metadata,) = _supplementary(
+        [{"name": "Height distribution", "x": [1.0], "y": [2.0], "visible": False}]
+    )
+    assert metadata["name"] == "Height distribution"
+    assert metadata["nbDataPoints"] == 1
+    assert metadata["visible"] is False
+
+
+def test_ignores_undefined_data_points():
+    """A series can carry NaN for a point that has no value; it says nothing about
+    the extent of the data."""
+    (metadata,) = _supplementary(
+        [{"name": "s", "x": [1.0, np.nan, 3.0], "y": [np.nan, 2.0, 4.0]}]
+    )
+    assert metadata["xRange"] == [1.0, 3.0]
+    assert metadata["yRange"] == [2.0, 4.0]
+
+
+def test_ignores_infinities():
+    """A distribution can diverge, which is not an extent either."""
+    (metadata,) = _supplementary(
+        [{"name": "s", "x": [1.0, 2.0], "y": [np.inf, 5.0]}]
+    )
+    assert metadata["yRange"] == [5.0, 5.0]
+
+
+def test_no_range_when_nothing_is_finite():
+    (metadata,) = _supplementary([{"name": "s", "x": [np.nan], "y": [np.inf]}])
+    assert "xRange" not in metadata
+    assert "yRange" not in metadata
+
+
+def test_no_range_for_an_empty_series():
+    (metadata,) = _supplementary([{"name": "s", "x": [], "y": []}])
+    assert metadata["nbDataPoints"] == 0
+    assert "xRange" not in metadata
+    assert "yRange" not in metadata
+
+
+def test_series_without_a_y_axis():
+    (metadata,) = _supplementary([{"name": "s", "x": [1.0, 4.0]}])
+    assert metadata["xRange"] == [1.0, 4.0]
+    assert "yRange" not in metadata
+
+
+def test_ranges_are_plain_floats():
+    """The metadata is serialized to JSON, so numpy scalars would have to be
+    encoded specially."""
+    (metadata,) = _supplementary(
+        [{"name": "s", "x": np.array([1.0, 2.0]), "y": np.array([3.0, 4.0])}]
+    )
+    assert all(type(v) is float for v in metadata["xRange"] + metadata["yRange"])
+
+
+def test_each_series_gets_its_own_range():
+    first, second = _supplementary(
+        [
+            {"name": "a", "x": [1.0, 2.0], "y": [1.0, 1.0]},
+            {"name": "b", "x": [10.0, 20.0], "y": [2.0, 2.0]},
+        ]
+    )
+    assert first["xRange"] == [1.0, 2.0]
+    assert second["xRange"] == [10.0, 20.0]

--- a/topobank/analysis/legacy/workflows.py
+++ b/topobank/analysis/legacy/workflows.py
@@ -92,6 +92,29 @@ def reasonable_bins_argument(topography):
         # return 'auto'
 
 
+def _finite_range(values):
+    """Smallest and largest finite value of a data series.
+
+    Parameters
+    ----------
+    values : array_like
+        The data.
+
+    Returns
+    -------
+    list of float or None
+        `[minimum, maximum]`, or None if nothing in the series is finite. Series
+        can carry NaN (an undefined data point) and infinities (a distribution
+        that diverges), neither of which says anything about the extent of the
+        data.
+    """
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        return None
+    return [float(finite.min()), float(finite.max())]
+
+
 def wrap_series(series, primary_key="x"):
     """
     Wrap each data series into a `SplitDictionaryHere` with a consecutive name
@@ -115,6 +138,16 @@ def wrap_series(series, primary_key="x"):
         supplementary = {"name": s["name"], "nbDataPoints": len(s[primary_key])}
         if "visible" in s:
             supplementary["visible"] = s["visible"]
+        # The extent of the data, recorded here because this is where the series
+        # is still in memory. A plot that combines several results needs it to
+        # choose a display unit that suits the data, and reading the series back
+        # out of the object store to find out would defeat the purpose of
+        # splitting them off (ContactEngineering/ce-ui#39).
+        for axis, key in (("x", primary_key), ("y", "y")):
+            if key in s:
+                data_range = _finite_range(s[key])
+                if data_range is not None:
+                    supplementary[f"{axis}Range"] = data_range
         wrapped_series.append(
             SplitDictionaryHere(f"series-{i}", s, supplementary=supplementary)
         )


### PR DESCRIPTION
First half of ContactEngineering/ce-ui#39:

> Some surfaces seem to have natural units, like nm or microns. Other surfaces seem to have very strange units, like 1.000e-4 mm. Can we eliminate the latter?

An analysis reports its results in the unit of the measurement it ran on, and a card labels its axes in the unit of the first result. That unit need not suit the data: a measurement stored in millimetres but a hundred nanometres across gives an axis of 1×10⁻⁴ mm.

## What this adds

Choosing a unit that fits requires knowing how large the data is — and the data lives in a file of its own in the object store, so reading it back to find out would defeat the point of splitting it off. `wrap_series` therefore records the extent of each series next to the reference to its file (`xRange`, `yRange`), where it costs nothing: the series is in memory at that moment anyway.

NaN (an undefined data point) and infinities (a distribution that diverges) are left out, since neither says anything about the extent of the data. A series with nothing finite in it records no extent at all, and the consumer falls back to the unit the analysis reported — which is today's behaviour, so nothing regresses for analyses computed before this.

The consumer is ContactEngineering/topobank-rest-api#13, which picks the display unit from these extents. Nothing in the frontend changes: it already multiplies by the per-analysis scale factor the card sends and renders the label the card builds.

## Testing

9 tests in `tests/analysis/test_series_metadata.py`: both axes, existing metadata preserved, NaN and infinity ignored, the all-non-finite and empty cases, a series without a y axis, plain floats rather than numpy scalars (the metadata is serialized to JSON), and per-series independence. Full suite green: 354 passed, 1 skipped.

The consuming PR also has a contract test that runs `wrap_series` and reads the result back, so a rename on either side fails visibly.

Refs ContactEngineering/ce-ui#39

🤖 Generated with [Claude Code](https://claude.com/claude-code)