### PR TITLE
BUG: Register custodian reap_lost_tasks so beat can actually schedule it

### DIFF
--- a/topobank/taskapp/celeryapp.py
+++ b/topobank/taskapp/celeryapp.py
@@ -34,6 +34,11 @@ class CeleryAppConfig(AppConfig):
         _log.info("Autodiscovering tasks in apps: {}".format(installed_apps))
         app.autodiscover_tasks(lambda: installed_apps, force=True)
 
+        # Autodiscovery only imports each app's `tasks` module, so the tasks
+        # defined in `custodian` below would stay unregistered - and the beat
+        # entry further down schedules one of them by name.
+        from . import custodian  # noqa: F401
+
         #
         # I had problems using the celery signal 'on_after_configure'.
         # Also see here: https://github.com/celery/celery/issues/3589


### PR DESCRIPTION
## Problem

`reap_lost_tasks` is scheduled by Celery beat but never registered on the worker, so it has never actually run since it was introduced in a0b7e4ca ("ENH: Fail tasks whose worker disappeared").

`CeleryAppConfig.ready()` schedules it by name:

```python
"taskapp-reap-lost-tasks": {
    "task": "topobank.taskapp.custodian.reap_lost_tasks",
    "schedule": 600,  # Every 10 minutes
    ...
}
```

But nothing ever imports `topobank.taskapp.custodian`. `autodiscover_tasks()` only imports each app's `tasks` module, and `topobank/taskapp/tasks.py` defines only `ProgressRecorder`. The sibling apps avoid this because their `AppConfig.ready()` imports their custodian explicitly — `topobank/manager/apps.py` and `topobank/analysis/apps.py` both do `from . import custodian` — but `taskapp`'s config never did.

Beat only needs the task *name* to enqueue, so the entry fires fine every 10 minutes and the worker then rejects each message:

```
Received unregistered task of type 'topobank.taskapp.custodian.reap_lost_tasks'.
The message has been ignored and discarded.
KeyError: 'topobank.taskapp.custodian.reap_lost_tasks'
```

Two consequences:

1. **The reaper never runs.** Rows whose worker died stay in `STARTED` forever — exactly the failure mode a0b7e4ca was written to fix.
2. **The messages are not actually discarded from the broker.** Despite the log wording, the message is never acked. On an SQS broker it returns after the visibility timeout and is redelivered indefinitely, so the oldest-message age on the manager queue climbs without bound until the message exhausts `maxReceiveCount` and lands in the DLQ. With a 10-minute schedule this produces a steady stream of poison messages, a permanently aging queue, and queue-depth/age monitoring that never recovers.

## Fix

Import the module in `ready()`, matching the existing pattern in `manager` and `analysis`:

```python
from . import custodian  # noqa: F401
```

## Why this is safe

- `custodian` imports `from .celeryapp import app` and `from .models import TaskStateModel`. `app` is bound at module scope well before `ready()` is invoked, and Django guarantees the app registry and models are loaded before `ready()` runs — so there is no circular-import or premature-model-access risk. This is the same import shape `topobank/manager/apps.py` has been using.
- The registered task name is derived from module + function, giving `topobank.taskapp.custodian.reap_lost_tasks`, which matches the beat entry string exactly.
- No behavioural change beyond the scheduled task now being runnable.

## Verification

Confirmed against a live deployment: the worker logged the `KeyError` above once per beat interval, and the same SQS message IDs reappeared at exactly the visibility-timeout interval, confirming the messages were being redelivered rather than dropped.

Note that this only takes effect once workers are rebuilt with the change — the queued poison messages from before the fix drain via the DLQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
