### PR TITLE
TST: Cover the full-text search index

### DIFF
--- a/tests/manager/test_search_vector.py
+++ b/tests/manager/test_search_vector.py
@@ -1,0 +1,114 @@
+"""
+Tests for the full-text search index on `Surface`.
+
+`Surface.build_search_document` assembles the searchable text from a dataset and
+its measurements, and the signal handlers in `manager.signals` keep
+`Surface.search_vector` current as either changes. These tests pin down what ends
+up in the index and, just as importantly, which saves do *not* trigger a
+re-index.
+"""
+
+import pytest
+from django.contrib.postgres.search import SearchQuery
+
+from topobank.manager.models import Surface, Topography
+from topobank.testing.factories import (
+    SurfaceFactory,
+    TagFactory,
+    Topography2DFactory,
+)
+
+
+def search(term):
+    return Surface.objects.filter(search_vector=SearchQuery(term, config="english"))
+
+
+@pytest.mark.django_db
+def test_measurement_name_is_indexed():
+    surface = SurfaceFactory(name="A dataset")
+    Topography2DFactory(surface=surface, name="distinctive-measurement.txt")
+
+    surface.refresh_from_db()
+    assert "distinctive" in str(surface.search_vector)
+    assert surface in search("distinctive")
+
+
+@pytest.mark.django_db
+def test_measurement_description_is_indexed():
+    surface = SurfaceFactory()
+    Topography2DFactory(surface=surface, description="sputtered aluminium")
+
+    assert surface in search("sputtered")
+
+
+@pytest.mark.django_db
+def test_renaming_a_measurement_reindexes_its_dataset():
+    surface = SurfaceFactory()
+    # Note: the index uses the 'english' configuration, so the terms must not be
+    # stop words ("before"/"after" would be stripped).
+    topography = Topography2DFactory(surface=surface, name="aluminium.txt")
+    assert surface in search("aluminium")
+
+    topography.name = "titanium.txt"
+    topography.save(update_fields=["name"])
+
+    assert surface in search("titanium")
+    assert surface not in search("aluminium")
+
+
+@pytest.mark.django_db
+def test_measurement_tags_are_indexed():
+    surface = SurfaceFactory()
+    topography = Topography2DFactory(surface=surface)
+    tag = TagFactory(name="anodized")
+
+    topography.tags = [tag]
+    topography.save()
+
+    assert surface in search("anodized")
+
+
+@pytest.mark.django_db
+def test_deleting_a_measurement_reindexes_its_dataset():
+    surface = SurfaceFactory()
+    topography = Topography2DFactory(surface=surface, name="doomed.txt")
+    assert surface in search("doomed")
+
+    topography.delete()
+
+    assert surface not in search("doomed")
+
+
+@pytest.mark.django_db
+def test_a_save_that_touches_no_searchable_field_does_not_reindex(mocker):
+    """
+    Only `name`, `description` and `created_by` contribute to the document.
+
+    Worth pinning down: physical metadata is rewritten on every inspection, and
+    re-indexing the whole dataset on each of those would be pure overhead. The
+    assertion is on `update_search_vector` rather than on the stored vector,
+    because recomputing the document would leave the vector unchanged anyway --
+    that is exactly the wasted work being guarded against.
+    """
+    surface = SurfaceFactory()
+    topography = Topography2DFactory(surface=surface, name="stable.txt")
+    reindex = mocker.patch.object(Surface, "update_search_vector")
+
+    topography.detrend_mode = "height"
+    topography.save(update_fields=["detrend_mode"])
+
+    reindex.assert_not_called()
+    assert Topography.objects.get(pk=topography.pk).detrend_mode == "height"
+
+
+@pytest.mark.django_db
+def test_a_save_that_touches_a_searchable_field_reindexes(mocker):
+    """The counterpart to the above: the guard must not swallow a real change."""
+    surface = SurfaceFactory()
+    topography = Topography2DFactory(surface=surface, name="stable.txt")
+    reindex = mocker.patch.object(Surface, "update_search_vector")
+
+    topography.name = "renamed.txt"
+    topography.save(update_fields=["name"])
+
+    reindex.assert_called()


### PR DESCRIPTION
First of the series splitting #1366 into separately reviewable pieces. This one is independent of that refactoring: it tests code that is **already on `main`**.

## Why

The full-text search index shipped in 1.70.0 with no tests. It is maintained by signal handlers rather than by anything a caller does explicitly, which makes a regression in it silent — search keeps working, it just quietly stops finding things. Every later PR in the series touches `build_search_document` or the handlers around it (the rename changes the relation the document walks), so having this covered first is what makes those changes safe to review.

## What is covered

Seven tests, all against the existing `Topography` API:

- A measurement's name, description and tags reach the dataset's document
- Renaming a measurement re-indexes its dataset, and the old term stops matching
- Deleting a measurement re-indexes its dataset
- The `_searchable_fields_changed` guard: a save touching no searchable field does **not** re-index, and one touching `name` does

The two guard tests assert on `Surface.update_search_vector` rather than on the stored vector. That is deliberate: a save that touches no searchable field would recompute an *identical* document, so asserting "the vector did not change" passes whether or not the guard fires — and the wasted recomputation is precisely what the guard exists to avoid. Physical metadata is rewritten on every inspection, so this path is hot.

## Verification

`flake8` clean, 7 passed locally.

Checked against mutants rather than only asserting they pass:

| Mutation | Result |
| --- | --- |
| `_searchable_fields_changed` forced to `return True` | the skip test fails, 6 pass |
| `build_search_document` iterating `[]` instead of measurements | the 5 indexing tests fail, 2 pass |

## Notes

No changelog entry: this adds no user-facing change, and the feature it covers was released in 1.70.0. The `2.0.0` section will be opened by the next PR in the series (the `Topography` → `Measurement` rename), which is where the actual compatibility break lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ENK9Ccwe1h2oe9xkiz5GA)_