### PR TITLE
API: Rename Topography to Measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for *TopoBank*
 
+# 2.0.0 (unreleased)
+
+- API: `Topography` is now `Measurement`. The model records a measurement --
+  identity, permissions, files and task state -- rather than something specific to
+  topography data; every measurement still holds height data, so this release only
+  renames it. `Surface.topography_set` is now `Surface.measurements`,
+  `num_topographies()` is `num_measurements()`, and
+  `WorkflowResult.subject_topography` is `subject_measurement`. There is no
+  compatibility alias, so out-of-tree code has to be updated.
+
 # 1.71.0 (2026-08-03)
 
 - ENH: A data series records the extent of its data next to the reference to its

--- a/tests/analysis/test_admin.py
+++ b/tests/analysis/test_admin.py
@@ -1,0 +1,88 @@
+"""
+Tests for the `WorkflowResult` admin.
+
+`SubjectTypeFilter` builds its lookup key by interpolating the selected value
+into ``subject_{value}__isnull``, so the value is not merely a label -- it has to
+match the name of a subject field on `WorkflowResult`. A mismatch is invisible
+until someone selects the filter in the admin, at which point the queryset raises
+`FieldError`, which is what these tests guard against.
+"""
+
+import pytest
+
+from topobank.analysis.admin import SubjectTypeFilter
+from topobank.analysis.models import WorkflowResult
+from topobank.testing.factories import (
+    MeasurementAnalysisFactory,
+    SurfaceAnalysisFactory,
+    SurfaceFactory,
+    TagAnalysisFactory,
+    TagFactory,
+)
+
+
+def filter_for(value):
+    """Build the filter with `value` selected, bypassing the request plumbing."""
+    subject_filter = SubjectTypeFilter.__new__(SubjectTypeFilter)
+    subject_filter.value = lambda: value
+    return subject_filter
+
+
+def test_every_offered_value_builds_a_valid_lookup():
+    """
+    Each value the filter offers must name an existing subject field.
+
+    The values come from `lookups` rather than being written out here, so that
+    this fails if the offered values and the model's fields drift apart -- which
+    is the whole failure mode. Needs no database: the `FieldError` is raised while
+    the lookup is resolved against the model, before any query runs.
+    """
+    for value, _label in filter_for(None).lookups(None, None):
+        queryset = filter_for(value).queryset(None, WorkflowResult.objects.all())
+        # An offered value that no branch handles would silently return the
+        # queryset untouched, so check the filter was actually applied.
+        assert queryset.query.where, f"{value!r} is offered but filters nothing"
+        str(queryset.query)  # forces lookup resolution
+
+
+def test_an_unknown_value_is_ignored_rather_than_raising():
+    queryset = WorkflowResult.objects.all()
+    assert filter_for("nonsense").queryset(None, queryset) is queryset
+
+
+def test_the_offered_values_are_exactly_the_ones_handled():
+    """
+    The lookups and the `queryset` branch are two lists that have to agree.
+
+    They are written out separately, so a value added to one and not the other
+    would silently do nothing.
+    """
+    offered = {value for value, _label in filter_for(None).lookups(None, None)}
+    assert offered == {"tag", "surface", "measurement"}
+
+
+@pytest.mark.django_db
+def test_the_measurement_filter_selects_measurement_results():
+    """The filter has to actually select, not just resolve."""
+    measurement_analysis = MeasurementAnalysisFactory()
+    SurfaceAnalysisFactory()
+    surface = SurfaceFactory()
+    tag = TagFactory.create(surfaces=[surface])
+    # A tag resolves its surfaces through the permission system, so it needs an
+    # authorized user before an analysis can be built for it.
+    tag.authorize_user(surface.created_by, "view")
+    TagAnalysisFactory(subject_tag=tag)
+
+    selected = filter_for("measurement").queryset(None, WorkflowResult.objects.all())
+
+    assert list(selected) == [measurement_analysis]
+
+
+@pytest.mark.django_db
+def test_the_subject_type_column_names_the_model():
+    from topobank.analysis.admin import WorkflowResultAdmin
+
+    analysis = MeasurementAnalysisFactory()
+    admin = WorkflowResultAdmin.__new__(WorkflowResultAdmin)
+
+    assert admin.subject_type(analysis) == "Measurement"

--- a/tests/analysis/test_custodian.py
+++ b/tests/analysis/test_custodian.py
@@ -21,7 +21,7 @@ from django.utils import timezone
 
 from topobank.analysis.custodian import periodic_cleanup
 from topobank.analysis.models import WorkflowResult
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 
 def _set_unmanaged_fields(analysis, **fields):
@@ -40,9 +40,9 @@ def _set_unmanaged_fields(analysis, **fields):
 
 @pytest.mark.django_db
 def test_deletes_long_deprecated_unnamed_result_with_subject():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     assert analysis.name is None
-    assert analysis.subject_topography is not None
+    assert analysis.subject_measurement is not None
 
     _set_unmanaged_fields(
         analysis,
@@ -59,7 +59,7 @@ def test_deletes_long_deprecated_unnamed_result_with_subject():
 @pytest.mark.django_db
 def test_keeps_recently_deprecated_result():
     # Deprecated, but still inside the grace period -> must survive.
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     _set_unmanaged_fields(
         analysis,
         deprecation_time=timezone.now()
@@ -75,7 +75,7 @@ def test_keeps_recently_deprecated_result():
 @pytest.mark.django_db
 def test_keeps_named_result_even_if_long_deprecated():
     # A named result is a saved/user-facing result and must never be auto-deleted.
-    analysis = TopographyAnalysisFactory(name="my-saved-analysis")
+    analysis = MeasurementAnalysisFactory(name="my-saved-analysis")
     _set_unmanaged_fields(
         analysis,
         deprecation_time=timezone.now()
@@ -91,7 +91,7 @@ def test_keeps_named_result_even_if_long_deprecated():
 @pytest.mark.django_db
 def test_keeps_active_non_deprecated_result():
     # deprecation_time is NULL -> active result, never eligible for cleanup.
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     assert analysis.deprecation_time is None
 
     periodic_cleanup()
@@ -106,7 +106,7 @@ def test_keeps_active_non_deprecated_result():
 
 @pytest.mark.django_db
 def test_marks_stuck_pending_result_as_failure():
-    analysis = TopographyAnalysisFactory(
+    analysis = MeasurementAnalysisFactory(
         task_state=WorkflowResult.PENDING, task_id=None
     )
     _set_unmanaged_fields(
@@ -125,7 +125,7 @@ def test_marks_stuck_pending_result_as_failure():
 @pytest.mark.django_db
 def test_keeps_recent_pending_result():
     # Pending for less than a day -> give it more time, leave untouched.
-    analysis = TopographyAnalysisFactory(
+    analysis = MeasurementAnalysisFactory(
         task_state=WorkflowResult.PENDING, task_id=None
     )
 
@@ -138,7 +138,7 @@ def test_keeps_recent_pending_result():
 @pytest.mark.django_db
 def test_keeps_pending_result_that_has_a_task_id():
     # A task id means the task was actually dispatched -> not "stuck".
-    analysis = TopographyAnalysisFactory(
+    analysis = MeasurementAnalysisFactory(
         task_state=WorkflowResult.PENDING, task_id=uuid.uuid4()
     )
     _set_unmanaged_fields(

--- a/tests/analysis/test_dependency_traceback.py
+++ b/tests/analysis/test_dependency_traceback.py
@@ -7,7 +7,7 @@ import pytest
 
 from topobank.analysis.models import Workflow, WorkflowResult
 from topobank.analysis.tasks import execute_workflow, schedule_workflow
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 DEP_TRACEBACK = "DEP TRACEBACK: exploded at line 42"
 DEP_ERROR = "boom in dep"
@@ -17,8 +17,8 @@ def _pending(topo, workflow_name="topobank.testing.test", **kwargs):
     from topobank.analysis.models import Workflow
 
     wf = Workflow(name=workflow_name)
-    return TopographyAnalysisFactory.create(
-        subject_topography=topo,
+    return MeasurementAnalysisFactory.create(
+        subject_measurement=topo,
         workflow_name=workflow_name,
         kwargs=wf.get_default_kwargs(),
         result=None,
@@ -65,8 +65,8 @@ def test_schedule_workflow_copies_finished_failed_dependency_traceback(two_topos
     # the (workflow_name, subject_hash, kwargs) that prepare_dependency_tasks
     # looks up, already in a FAILED state.
     for dep_kwargs in [dict(a=1), dict(b="A")]:
-        dep = TopographyAnalysisFactory.create(
-            subject_topography=topo,
+        dep = MeasurementAnalysisFactory.create(
+            subject_measurement=topo,
             workflow_name="topobank.testing.test",
             kwargs=dep_wf.clean_kwargs(dep_kwargs),
             subject_hash=subject_hash,

--- a/tests/analysis/test_export_zip.py
+++ b/tests/analysis/test_export_zip.py
@@ -24,9 +24,9 @@ from topobank.analysis.models import WorkflowResult
 from topobank.analysis.zip_model import ResultZipContainer
 from topobank.files.models import Manifest
 from topobank.testing.factories import (
-    FailedTopographyAnalysisFactory,
+    FailedMeasurementAnalysisFactory,
     PermissionSetFactory,
-    TopographyAnalysisFactory,
+    MeasurementAnalysisFactory,
 )
 
 
@@ -40,7 +40,7 @@ def _archive(results):
 
 @pytest.mark.django_db
 def test_archive_contains_result_files_and_metadata():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     directory = analysis.subject.name.lower()
 
     with _archive([analysis]) as zip_file:
@@ -58,7 +58,7 @@ def test_archive_contains_result_files_and_metadata():
 
 @pytest.mark.django_db
 def test_archive_directory_is_named_after_the_subject():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     with _archive([analysis]) as zip_file:
         directories = {name.split("/")[0] for name in zip_file.namelist()}
         directories.discard("README.txt")
@@ -67,10 +67,10 @@ def test_archive_directory_is_named_after_the_subject():
 
 @pytest.mark.django_db
 def test_archive_disambiguates_subjects_with_the_same_name():
-    first = TopographyAnalysisFactory()
+    first = MeasurementAnalysisFactory()
     # Measurement names are unique only within a dataset, so two results can
     # well have equally named subjects.
-    second = TopographyAnalysisFactory(subject_topography__name=first.subject.name)
+    second = MeasurementAnalysisFactory(subject_measurement__name=first.subject.name)
     assert first.subject.name == second.subject.name
     assert first.subject.surface != second.subject.surface
 
@@ -84,7 +84,7 @@ def test_archive_disambiguates_subjects_with_the_same_name():
 
 @pytest.mark.django_db
 def test_archive_skips_display_only_artifacts():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     # Deep-zoom tiles are a rendering of data that is archived anyway; they must
     # not be bundled, or an archive would grow by thousands of small files.
     analysis.folder.save_file(
@@ -101,7 +101,7 @@ def test_archive_skips_display_only_artifacts():
 
 @pytest.mark.django_db
 def test_archive_reports_unreadable_files_in_place(mocker):
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     mocker.patch(
         "topobank.files.models.Manifest.open", side_effect=OSError("file is gone")
     )
@@ -118,7 +118,7 @@ def test_archive_reports_unreadable_files_in_place(mocker):
 
 @pytest.mark.django_db
 def test_info_text_describes_the_analysis():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     info = result_info_text(analysis)
     assert analysis.subject.name in info
     assert "Start time of analysis task" in info
@@ -127,7 +127,7 @@ def test_info_text_describes_the_analysis():
 
 @pytest.mark.django_db
 def test_info_text_asks_for_citation_of_dois():
-    analysis = TopographyAnalysisFactory(dois=["10.1000/xyz"])
+    analysis = MeasurementAnalysisFactory(dois=["10.1000/xyz"])
     info = result_info_text(analysis)
     assert "PLEASE CITE" in info
     assert "10.1000/xyz" in info
@@ -135,13 +135,13 @@ def test_info_text_asks_for_citation_of_dois():
 
 @pytest.mark.django_db
 def test_info_text_without_configuration():
-    analysis = TopographyAnalysisFactory(configuration=None)
+    analysis = MeasurementAnalysisFactory(configuration=None)
     assert "Please recalculate" in result_info_text(analysis)
 
 
 @pytest.mark.django_db
 def test_readme_includes_workflow_specific_documentation(mocker):
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     implementation = analysis.implementation
     mocker.patch.object(
         implementation.Meta, "download_readme", "Contents of a test result", create=True
@@ -163,7 +163,7 @@ class RecordingProgressRecorder:
 
 @pytest.mark.django_db
 def test_bundling_reports_progress():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     nb_files = analysis.folder.get_valid_files().count()
     assert nb_files > 0
 
@@ -188,7 +188,7 @@ def test_progress_counts_only_the_files_that_are_bundled():
     of them against a handful of data files). Counting those would drive the bar
     to ~99% instantly and then leave it there for the whole real work.
     """
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     nb_files = analysis.folder.get_valid_files().count()
     for i in range(50):
         analysis.folder.save_file(
@@ -208,7 +208,7 @@ def test_progress_counts_only_the_files_that_are_bundled():
 
 @pytest.mark.django_db
 def test_bundling_without_a_progress_recorder_still_works():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     with _archive([analysis]) as zip_file:
         assert "README.txt" in zip_file.namelist()
 
@@ -216,7 +216,7 @@ def test_bundling_without_a_progress_recorder_still_works():
 @pytest.mark.django_db
 def test_task_worker_passes_the_progress_recorder_through():
     """`run_task` injects a recorder; it has to reach the exporter."""
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
 
     recorder = RecordingProgressRecorder()
@@ -238,7 +238,7 @@ def _container(user):
 
 @pytest.mark.django_db
 def test_container_stores_the_archive():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
 
     container.task_worker(result_ids=[analysis.id])
@@ -252,7 +252,7 @@ def test_container_stores_the_archive():
 @pytest.mark.django_db
 def test_container_refuses_results_the_user_cannot_see(two_users):
     (user1, user2), (surface1, surface2, surface3) = two_users
-    analysis = TopographyAnalysisFactory(subject_topography__surface=surface1)
+    analysis = MeasurementAnalysisFactory(subject_measurement__surface=surface1)
     container = _container(user2)
 
     with pytest.raises(PermissionDenied):
@@ -261,9 +261,9 @@ def test_container_refuses_results_the_user_cannot_see(two_users):
 
 @pytest.mark.django_db
 def test_container_skips_results_without_data():
-    failed = FailedTopographyAnalysisFactory(task_state=WorkflowResult.FAILURE)
-    successful = TopographyAnalysisFactory(
-        subject_topography__surface=failed.subject.surface
+    failed = FailedMeasurementAnalysisFactory(task_state=WorkflowResult.FAILURE)
+    successful = MeasurementAnalysisFactory(
+        subject_measurement__surface=failed.subject.surface
     )
     container = _container(successful.permissions.user_permissions.first().user)
 
@@ -277,7 +277,7 @@ def test_container_skips_results_without_data():
 
 @pytest.mark.django_db
 def test_container_fails_if_nothing_can_be_bundled():
-    failed = FailedTopographyAnalysisFactory(task_state=WorkflowResult.FAILURE)
+    failed = FailedMeasurementAnalysisFactory(task_state=WorkflowResult.FAILURE)
     container = _container(failed.permissions.user_permissions.first().user)
 
     with pytest.raises(RuntimeError):
@@ -286,7 +286,7 @@ def test_container_fails_if_nothing_can_be_bundled():
 
 @pytest.mark.django_db
 def test_custodian_removes_expired_containers():
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     user = analysis.permissions.user_permissions.first().user
     expired = _container(user)
     fresh = _container(user)
@@ -316,7 +316,7 @@ def test_custodian_also_removes_the_archive_of_an_expired_container():
     archive (nor the file in the object store) if deleting the container did not
     take the manifest with it.
     """
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
     container.task_worker(result_ids=[analysis.id])
 
@@ -334,7 +334,7 @@ def test_custodian_also_removes_the_archive_of_an_expired_container():
 @pytest.mark.django_db
 def test_deleting_a_container_directly_also_removes_the_archive():
     """The same has to hold for a single delete, e.g. from the admin."""
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
     container.task_worker(result_ids=[analysis.id])
 
@@ -350,7 +350,7 @@ def test_deleting_a_container_directly_also_removes_the_archive():
 @pytest.mark.django_db
 def test_deleting_a_container_without_an_archive_is_harmless():
     """A container whose task never ran has no manifest to collect."""
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
     assert container.manifest is None
 
@@ -365,7 +365,7 @@ def test_analysis_container_uses_spooled_temporary_file_with_setting(mocker, set
     settings.TOPOBANK_SPOOL_MAX_SIZE = 987654
     spooled_mock = mocker.patch("tempfile.SpooledTemporaryFile", wraps=tempfile.SpooledTemporaryFile)
 
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     container = _container(analysis.permissions.user_permissions.first().user)
     container.task_worker(result_ids=[analysis.id])
 

--- a/tests/analysis/test_models.py
+++ b/tests/analysis/test_models.py
@@ -13,14 +13,14 @@ from topobank.analysis.registry import (
 )
 from topobank.analysis.tasks import get_current_configuration
 from topobank.files.models import Manifest
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import (
     SurfaceAnalysisFactory,
     SurfaceFactory,
     TagAnalysisFactory,
     TagFactory,
     Topography1DFactory,
-    TopographyAnalysisFactory,
+    MeasurementAnalysisFactory,
 )
 from topobank.testing.workflows import TestImplementation
 
@@ -28,7 +28,7 @@ from topobank.testing.workflows import TestImplementation
 @pytest.mark.django_db
 def test_topography_as_analysis_subject():
     topo = Topography1DFactory()
-    analysis = TopographyAnalysisFactory(subject_topography=topo)
+    analysis = MeasurementAnalysisFactory(subject_measurement=topo)
     assert analysis.subject == topo
 
 
@@ -54,7 +54,7 @@ def test_tag_as_analysis_subject():
 def test_exception_implementation_missing(test_workflow):
     # We create an implementation for surfaces, but not for analyses
     function = Workflow(name="topobank.testing.topography_only_test")
-    analysis = TopographyAnalysisFactory(workflow_name=function.name)
+    analysis = MeasurementAnalysisFactory(workflow_name=function.name)
     analysis.folder.remove_files()
     function.eval(analysis)  # that's okay, it's implemented
     analysis = SurfaceAnalysisFactory()
@@ -68,8 +68,8 @@ def test_workflow_eval(test_workflow):
 
     surface = SurfaceFactory()
     t = Topography1DFactory(surface=surface)
-    analysis = TopographyAnalysisFactory.create(
-        subject_topography=t,
+    analysis = MeasurementAnalysisFactory.create(
+        subject_measurement=t,
         kwargs=dict(a=2, b="bar"),
     )
     analysis.folder.remove_files()  # Make sure there are no files
@@ -82,8 +82,8 @@ def test_workflow_eval(test_workflow):
 def test_analysis_times(two_topos, test_workflow):
     now = timezone.now()
 
-    analysis = TopographyAnalysisFactory.create(
-        subject_topography=Topography.objects.first(),
+    analysis = MeasurementAnalysisFactory.create(
+        subject_measurement=Measurement.objects.first(),
         task_state=WorkflowResult.SUCCESS,
         kwargs={"a": 2, "b": "abcdef"},
         task_start_time=datetime.datetime(2018, 1, 1, 12),
@@ -186,7 +186,7 @@ def test_current_configuration(settings):
 
 @pytest.mark.django_db
 def test_analysis_delete_removes_files(test_workflow):
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     assert len(analysis.folder) == 4
     file_path = analysis.folder.files.first().file.name
     assert default_storage.exists(file_path)
@@ -200,7 +200,7 @@ def test_analysis_delete_removes_files(test_workflow):
 def test_fix_folder(test_workflow):
     # Old analyses do not have folders
     assert Manifest.objects.count() == 0
-    analysis = TopographyAnalysisFactory(
+    analysis = MeasurementAnalysisFactory(
         workflow_name=test_workflow.name,
         folder=None,
     )
@@ -223,6 +223,6 @@ def test_fix_folder(test_workflow):
 
 @pytest.mark.django_db
 def test_submit_again(test_workflow):
-    analysis = TopographyAnalysisFactory()
+    analysis = MeasurementAnalysisFactory()
     new_analysis = analysis.submit_again()
     assert new_analysis.task_state == WorkflowResult.PENDING

--- a/tests/analysis/test_sharing.py
+++ b/tests/analysis/test_sharing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from topobank.analysis.controller import AnalysisController
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import TagFactory
 
 
@@ -9,7 +9,7 @@ from topobank.testing.factories import TagFactory
 def test_topography_analysis(two_users, test_workflow):
     (user1, user2), (surface1, surface2, surface3) = two_users
 
-    topography1, topography2, topography3 = Topography.objects.all()
+    topography1, topography2, topography3 = Measurement.objects.all()
 
     controller = AnalysisController(
         user1, subjects=[topography1], workflow=test_workflow

--- a/tests/analysis/test_submit_viable_result.py
+++ b/tests/analysis/test_submit_viable_result.py
@@ -24,7 +24,7 @@ def test_submit_returns_successful_over_notrun(test_workflow, user_alice):
     def _make(state, start):
         wr = WorkflowResult.objects.create(
             workflow_name=test_workflow.name,
-            subject_topography=topo,
+            subject_measurement=topo,
             kwargs=kwargs,
             created_by=user_alice,
             task_state=state,

--- a/tests/analysis/test_surface_set_invalidation.py
+++ b/tests/analysis/test_surface_set_invalidation.py
@@ -16,10 +16,10 @@ from topobank.analysis.custodian import periodic_cleanup
 from topobank.analysis.models import WorkflowResult
 from topobank.analysis.signals import (
     delete_all_related_analyses,
-    pre_delete_topography,
+    pre_delete_measurement,
     pre_measurement_save,
 )
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import SurfaceFactory, Topography2DFactory
 
 
@@ -39,7 +39,7 @@ def test_refresh_cache_deprecates_surface_set_analysis(test_workflow, user_alice
     unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
     assert affected.deprecation_time is None
 
-    delete_all_related_analyses(sender=Topography, instance=topo)
+    delete_all_related_analyses(sender=Measurement, instance=topo)
 
     affected.refresh_from_db()
     unrelated.refresh_from_db()
@@ -56,8 +56,8 @@ def test_new_measurement_deletes_surface_set_analysis(test_workflow, user_alice)
     unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
 
     # A brand-new (unsaved) measurement added to s1.
-    new_topo = Topography(surface=s1)  # pk is None -> "created" branch
-    pre_measurement_save(sender=Topography, instance=new_topo)
+    new_topo = Measurement(surface=s1)  # pk is None -> "created" branch
+    pre_measurement_save(sender=Measurement, instance=new_topo)
 
     assert not WorkflowResult.objects.filter(pk=affected.pk).exists()
     assert WorkflowResult.objects.filter(pk=unrelated.pk).exists()
@@ -69,7 +69,7 @@ def test_new_measurement_does_not_touch_unrelated_surface_analyses(
 ):
     """A new measurement must not delete surface/tag analyses of other surfaces.
 
-    Regression guard for the ``subject_topography=<unsaved>`` -> ``IS NULL``
+    Regression guard for the ``subject_measurement=<unsaved>`` -> ``IS NULL``
     trap: an unsaved instance must be scoped by surface only.
     """
     s1 = SurfaceFactory(created_by=user_alice)
@@ -79,8 +79,8 @@ def test_new_measurement_does_not_touch_unrelated_surface_analyses(
 
     unrelated_surface_analysis = SurfaceAnalysisFactory(subject_surface=other)
 
-    new_topo = Topography(surface=s1)
-    pre_measurement_save(sender=Topography, instance=new_topo)
+    new_topo = Measurement(surface=s1)
+    pre_measurement_save(sender=Measurement, instance=new_topo)
 
     assert WorkflowResult.objects.filter(
         pk=unrelated_surface_analysis.pk
@@ -96,7 +96,7 @@ def test_delete_topography_deletes_surface_set_analysis(test_workflow, user_alic
     affected = _surface_set_analysis(test_workflow, user_alice, [s1])
     unrelated = _surface_set_analysis(test_workflow, user_alice, [other])
 
-    pre_delete_topography(sender=Topography, instance=topo)
+    pre_delete_measurement(sender=Measurement, instance=topo)
 
     assert not WorkflowResult.objects.filter(pk=affected.pk).exists()
     assert WorkflowResult.objects.filter(pk=unrelated.pk).exists()

--- a/tests/analysis/test_surface_set_workflows.py
+++ b/tests/analysis/test_surface_set_workflows.py
@@ -13,7 +13,7 @@ Note: Submit tests assert DB state only — without ``transaction=True`` the
 ``transaction.on_commit`` hook in ``submit_analysis_task_to_celery`` is
 silently skipped, so no Celery dispatch happens (mirrors ``test_submit_again``).
 Coverage of ``_get_dependencies_for_surfaces`` is deferred; the existing test
-workflow implementations only define ``Topography`` dependencies, so meaningful
+workflow implementations only define ``Measurement`` dependencies, so meaningful
 coverage requires a new registered implementation.
 """
 
@@ -29,7 +29,7 @@ from topobank.files.utils import file_storage_path
 from topobank.testing.factories import (
     SurfaceFactory,
     Topography2DFactory,
-    TopographyAnalysisFactory,
+    MeasurementAnalysisFactory,
 )
 from topobank.testing.workflows import TestImplementation
 
@@ -90,7 +90,7 @@ def test_workflow_result_compute_subject_hash_static_matches_module_function():
 def test_update_subject_hash_reads_m2m_and_falls_back_to_fk(test_workflow):
     s1 = SurfaceFactory()
     s2 = SurfaceFactory()
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
     analysis.surfaces.set([s1, s2])
 
     analysis.update_subject_hash()
@@ -101,7 +101,7 @@ def test_update_subject_hash_reads_m2m_and_falls_back_to_fk(test_workflow):
     analysis.update_subject_hash()
     analysis.refresh_from_db()
     assert analysis.subject_hash == compute_subject_hash(
-        "topography", [analysis.subject_topography_id]
+        "topography", [analysis.subject_measurement_id]
     )
 
 
@@ -113,8 +113,8 @@ def test_update_subject_hash_reads_m2m_and_falls_back_to_fk(test_workflow):
 @pytest.mark.django_db
 def test_subject_returns_single_surface_for_one_surface_m2m(test_workflow):
     surface = SurfaceFactory()
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.surfaces.set([surface])
 
@@ -125,8 +125,8 @@ def test_subject_returns_single_surface_for_one_surface_m2m(test_workflow):
 def test_subject_returns_queryset_for_multi_surface_m2m(test_workflow):
     s1 = SurfaceFactory()
     s2 = SurfaceFactory()
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.surfaces.set([s1, s2])
 
@@ -138,8 +138,8 @@ def test_subject_returns_queryset_for_multi_surface_m2m(test_workflow):
 
 @pytest.mark.django_db
 def test_subject_is_none_with_no_dispatch_and_no_surfaces(test_workflow):
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
+    analysis.subject_measurement = None
     analysis.save()
     assert analysis.subject is None
 
@@ -162,7 +162,7 @@ def test_submit_for_surfaces_creates_workflow_result_with_m2m_and_hash(
 
     assert analysis.task_state == WorkflowResult.PENDING
     assert analysis.function == test_workflow
-    assert analysis.subject_topography is None
+    assert analysis.subject_measurement is None
     assert analysis.subject_surface is None
     assert analysis.subject_tag is None
     assert analysis.surfaces.count() == 2
@@ -250,8 +250,8 @@ def test_eval_surfaces_single_surface_uses_surface_implementation(
 ):
     surface = SurfaceFactory()
     Topography2DFactory(surface=surface)
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.folder.remove_files()
     analysis.surfaces.set([surface])
@@ -269,8 +269,8 @@ def test_eval_surfaces_multi_surface_routes_to_tag_implementation(
 ):
     s1 = SurfaceFactory()
     s2 = SurfaceFactory()
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.surfaces.set([s1, s2])
 
@@ -291,8 +291,8 @@ def test_eval_surfaces_falls_back_to_topography_when_no_surface_impl():
     function = Workflow(name="topobank.testing.topography_only_test")
     surface = SurfaceFactory()
     Topography2DFactory(surface=surface)
-    analysis = TopographyAnalysisFactory(workflow_name=function.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=function.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.folder.remove_files()
     analysis.surfaces.set([surface])
@@ -311,8 +311,8 @@ def test_eval_surfaces_raises_when_multi_surface_lacks_tag_impl():
     function = Workflow(name="topobank.testing.topography_only_test")
     s1 = SurfaceFactory()
     s2 = SurfaceFactory()
-    analysis = TopographyAnalysisFactory(workflow_name=function.name)
-    analysis.subject_topography = None
+    analysis = MeasurementAnalysisFactory(workflow_name=function.name)
+    analysis.subject_measurement = None
     analysis.save()
     analysis.surfaces.set([s1, s2])
 
@@ -322,7 +322,7 @@ def test_eval_surfaces_raises_when_multi_surface_lacks_tag_impl():
 
 @pytest.mark.django_db
 def test_eval_surfaces_raises_value_error_when_no_surfaces(test_workflow):
-    analysis = TopographyAnalysisFactory(workflow_name=test_workflow.name)
+    analysis = MeasurementAnalysisFactory(workflow_name=test_workflow.name)
     runner = test_workflow.implementation(**analysis.kwargs)
     with pytest.raises(ValueError, match="No surfaces in analysis"):
         runner.eval_surfaces(analysis)

--- a/tests/analysis/test_tasks.py
+++ b/tests/analysis/test_tasks.py
@@ -22,14 +22,14 @@ from topobank.analysis.tasks import (
     prepare_dependency_tasks,
     schedule_workflow,
 )
-from topobank.manager.models import Topography
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.manager.models import Measurement
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 
 def _pending_analysis(topo, workflow_name, **kwargs):
     wf = Workflow(name=workflow_name)
-    return TopographyAnalysisFactory.create(
-        subject_topography=topo,
+    return MeasurementAnalysisFactory.create(
+        subject_measurement=topo,
         workflow_name=workflow_name,
         kwargs=wf.get_default_kwargs(),
         result=None,
@@ -48,7 +48,7 @@ def test_current_statistics_empty():
     stats = current_statistics()
     assert stats == {
         "num_surfaces_excluding_publications": 0,
-        "num_topographies_excluding_publications": 0,
+        "num_measurements_excluding_publications": 0,
         "num_analyses_excluding_publications": 0,
     }
 
@@ -57,12 +57,12 @@ def test_current_statistics_empty():
 def test_current_statistics_counts(two_topos):
     stats = current_statistics()
     assert stats["num_surfaces_excluding_publications"] >= 1
-    assert stats["num_topographies_excluding_publications"] >= 2
+    assert stats["num_measurements_excluding_publications"] >= 2
 
 
 @pytest.mark.django_db
 def test_current_statistics_for_user(two_topos):
-    user = Topography.objects.first().created_by
+    user = Measurement.objects.first().created_by
     stats = current_statistics(user=user)
     assert stats["num_surfaces_excluding_publications"] >= 1
     # A user with no data sees zeros.
@@ -81,7 +81,7 @@ def test_current_statistics_for_user(two_topos):
 
 @pytest.mark.django_db
 def test_schedule_workflow_skips_completed_without_force(two_topos, test_workflow):
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test")
     WorkflowResult.objects.filter(pk=analysis.pk).update(
         task_state=WorkflowResult.SUCCESS
@@ -95,7 +95,7 @@ def test_schedule_workflow_skips_completed_without_force(two_topos, test_workflo
 
 @pytest.mark.django_db
 def test_execute_workflow_skips_failed(two_topos, test_workflow):
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test")
     WorkflowResult.objects.filter(pk=analysis.pk).update(
         task_state=WorkflowResult.FAILURE
@@ -114,7 +114,7 @@ def test_execute_workflow_skips_failed(two_topos, test_workflow):
 
 @pytest.mark.django_db
 def test_prepare_dependency_tasks_schedules_new_dependencies(two_topos, test_workflow):
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     parent = _pending_analysis(topo, "topobank.testing.test2")
 
     dependencies = parent.function.get_dependencies(parent)
@@ -132,7 +132,7 @@ def test_prepare_dependency_tasks_schedules_new_dependencies(two_topos, test_wor
 
 @pytest.mark.django_db
 def test_schedule_workflow_runs_dependencies_end_to_end(two_topos, test_workflow):
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test2")
 
     # force=True so dependencies are (re)resolved and run.
@@ -162,7 +162,7 @@ def test_workflow_produces_timing_information(two_topos, test_workflow):
     timing node named after itself, and implementations that opt in (accept a
     ``timer`` argument) nest their own sub-steps underneath.
     """
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test")
 
     perform_analysis.apply(args=(analysis.id, True))
@@ -192,7 +192,7 @@ def test_failed_workflow_persists_timing_information(two_topos, test_workflow):
     so even a workflow failing mid-flight leaves its partial duration behind —
     and the failure path must persist it.
     """
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test_error")
 
     perform_analysis.apply(args=(analysis.id, True))
@@ -226,7 +226,7 @@ def test_dependency_failure_marks_parent_failed(two_topos, test_workflow):
     rather than through ``chord`` so it does not depend on Celery's eager-chord
     execution.
     """
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
 
     # Parent: waiting on its dependency, exactly as schedule_workflow leaves it.
     parent = _pending_analysis(topo, "topobank.testing.test_error_in_dependency")
@@ -287,7 +287,7 @@ def _capture_execute_workflow_dispatches():
 
 @pytest.mark.django_db
 def test_dependency_dispatch_carries_parent_id(two_topos, test_workflow):
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     analysis = _pending_analysis(topo, "topobank.testing.test2")
 
     with _capture_execute_workflow_dispatches() as captured:
@@ -318,7 +318,7 @@ def test_rerun_by_second_parent_attributes_to_that_parent(two_topos, test_workfl
     id in the task kwargs, while the rows keep the creation-time stamp of the
     parent that created them — per-execution attribution does not depend on
     (or mutate) the shared row."""
-    topo = Topography.objects.first()
+    topo = Measurement.objects.first()
     parent_a = _pending_analysis(topo, "topobank.testing.test2")
     perform_analysis.apply(args=(parent_a.id, True))
 

--- a/tests/analysis/test_utils.py
+++ b/tests/analysis/test_utils.py
@@ -11,18 +11,18 @@ from topobank.analysis.utils import (
     merge_dicts,
     round_to_significant_digits,
 )
-from topobank.manager.models import Surface, Topography
-from topobank.testing.factories import TopographyAnalysisFactory, UserFactory
+from topobank.manager.models import Surface, Measurement
+from topobank.testing.factories import MeasurementAnalysisFactory, UserFactory
 
 
 @pytest.mark.django_db
 def test_request_analysis(two_topos, test_workflow):
-    topo1 = Topography.objects.get(name="Example 3 - ZSensor")
-    topo2 = Topography.objects.get(name="Example 4 - Default")
+    topo1 = Measurement.objects.get(name="Example 3 - ZSensor")
+    topo2 = Measurement.objects.get(name="Example 4 - Default")
 
     # delete all prior analyses for these two topographies in order to have a clean state
     WorkflowResult.objects.filter(
-        subject_topography__in=[topo1, topo2]
+        subject_measurement__in=[topo1, topo2]
     ).delete()
 
     user = topo1.created_by
@@ -36,22 +36,22 @@ def test_request_analysis(two_topos, test_workflow):
 
 @pytest.mark.django_db
 def test_latest_analyses(two_topos, test_workflow):
-    topo1 = Topography.objects.get(name="Example 3 - ZSensor")
-    topo2 = Topography.objects.get(name="Example 4 - Default")
+    topo1 = Measurement.objects.get(name="Example 3 - ZSensor")
+    topo2 = Measurement.objects.get(name="Example 4 - Default")
 
     user = topo1.created_by
 
     # delete all prior analyses for these two topographies in order to have a clean state
     WorkflowResult.objects.filter(
-        subject_topography__in=[topo1, topo2]
+        subject_measurement__in=[topo1, topo2]
     ).delete()
 
     #
-    # Topography 1
+    # Measurement 1
     #
-    TopographyAnalysisFactory.create(
+    MeasurementAnalysisFactory.create(
         user=user,
-        subject_topography=topo1,
+        subject_measurement=topo1,
         workflow_name=test_workflow.name,
         task_state=WorkflowResult.SUCCESS,
         kwargs=test_workflow.get_default_kwargs(),
@@ -60,9 +60,9 @@ def test_latest_analyses(two_topos, test_workflow):
     )
 
     # save a second only, which has a later start time
-    TopographyAnalysisFactory.create(
+    MeasurementAnalysisFactory.create(
         user=user,
-        subject_topography=topo1,
+        subject_measurement=topo1,
         workflow_name=test_workflow.name,
         task_state=WorkflowResult.SUCCESS,
         kwargs=test_workflow.get_default_kwargs(),
@@ -71,11 +71,11 @@ def test_latest_analyses(two_topos, test_workflow):
     )
 
     #
-    # Topography 2
+    # Measurement 2
     #
-    TopographyAnalysisFactory.create(
+    MeasurementAnalysisFactory.create(
         user=user,
-        subject_topography=topo2,
+        subject_measurement=topo2,
         workflow_name=test_workflow.name,
         task_state=WorkflowResult.SUCCESS,
         kwargs=test_workflow.get_default_kwargs(),
@@ -84,9 +84,9 @@ def test_latest_analyses(two_topos, test_workflow):
     )
 
     # save a second one, which has the latest start time
-    TopographyAnalysisFactory.create(
+    MeasurementAnalysisFactory.create(
         user=user,
-        subject_topography=topo2,
+        subject_measurement=topo2,
         workflow_name=test_workflow.name,
         task_state=WorkflowResult.SUCCESS,
         kwargs=test_workflow.get_default_kwargs(),
@@ -95,9 +95,9 @@ def test_latest_analyses(two_topos, test_workflow):
     )
 
     # save a third one, which has a later start time than the first
-    TopographyAnalysisFactory.create(
+    MeasurementAnalysisFactory.create(
         user=user,
-        subject_topography=topo2,
+        subject_measurement=topo2,
         workflow_name=test_workflow.name,
         task_state=WorkflowResult.SUCCESS,
         kwargs=test_workflow.get_default_kwargs(),
@@ -105,7 +105,7 @@ def test_latest_analyses(two_topos, test_workflow):
         task_end_time=datetime.datetime(2018, 1, 4, 13, 1, 1),
     )
 
-    ContentType.objects.get_for_model(Topography)
+    ContentType.objects.get_for_model(Measurement)
     analyses = AnalysisController(
         user, subjects=[topo1, topo2], workflow=test_workflow
     )
@@ -144,7 +144,7 @@ def test_latest_analyses_if_no_analyses(test_workflow):
 
 @pytest.mark.django_db
 def test_find_children(user_three_topographies_three_surfaces_three_tags):
-    topo1, topo2, topo3 = Topography.objects.all()
+    topo1, topo2, topo3 = Measurement.objects.all()
     surf1, surf2, surf3 = Surface.objects.all()
 
     assert set(find_children([surf1, surf2, topo3])) == set(
@@ -206,11 +206,11 @@ def test_filter_and_order_analyses_surface_before_its_topographies(test_workflow
     topo1 = Topography2DFactory(surface=surface)
     topo2 = Topography2DFactory(surface=surface)
 
-    ta1 = TopographyAnalysisFactory(
-        subject_topography=topo1, workflow_name=test_workflow.name, result=None
+    ta1 = MeasurementAnalysisFactory(
+        subject_measurement=topo1, workflow_name=test_workflow.name, result=None
     )
-    ta2 = TopographyAnalysisFactory(
-        subject_topography=topo2, workflow_name=test_workflow.name, result=None
+    ta2 = MeasurementAnalysisFactory(
+        subject_measurement=topo2, workflow_name=test_workflow.name, result=None
     )
     sa = SurfaceAnalysisFactory(
         subject_surface=surface, workflow_name=test_workflow.name, result=None
@@ -241,8 +241,8 @@ def test_filter_and_order_analyses_drops_surface_analysis_for_single_topography(
     surface = SurfaceFactory(created_by=user)
     topo = Topography2DFactory(surface=surface)
 
-    ta = TopographyAnalysisFactory(
-        subject_topography=topo, workflow_name=test_workflow.name, result=None
+    ta = MeasurementAnalysisFactory(
+        subject_measurement=topo, workflow_name=test_workflow.name, result=None
     )
     sa = SurfaceAnalysisFactory(
         subject_surface=surface, workflow_name=test_workflow.name, result=None

--- a/tests/analysis/test_workflows.py
+++ b/tests/analysis/test_workflows.py
@@ -32,7 +32,7 @@ def test_workflow_schema_generation():
         assert isinstance(default_kwargs, dict), f"Expected dict for defaults of {name}"
 
         # Test has_implementation doesn't crash on any model class
-        from topobank.manager.models import Surface, Tag, Topography
-        workflow.has_implementation(Topography)
+        from topobank.manager.models import Surface, Tag, Measurement
+        workflow.has_implementation(Measurement)
         workflow.has_implementation(Surface)
         workflow.has_implementation(Tag)

--- a/tests/manager/test_container_pipeline.py
+++ b/tests/manager/test_container_pipeline.py
@@ -15,7 +15,7 @@ small and assert several related things per test.
 
 import pytest
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import UserFactory
 from topobank.testing.utils import import_container_from_url_or_skip
 
@@ -32,11 +32,11 @@ def imported_surface(db):
 def test_container_import_and_datafile_read(imported_surface):
     surface = imported_surface
     assert surface.name == "Self-affine synthetic surface"
-    assert surface.topography_set.count() == 3
+    assert surface.measurements.count() == 3
 
     # The raw data file of each measurement can be reconstructed into a real
     # SurfaceTopography object.
-    for topo in surface.topography_set.all():
+    for topo in surface.measurements.all():
         st = topo.read()
         assert len(st.nb_grid_pts) == 2
         assert all(n > 0 for n in st.nb_grid_pts)
@@ -49,11 +49,11 @@ def test_full_inspection_via_task_runner(imported_surface):
 
     from topobank.taskapp.utils import task_dispatch
 
-    topo = imported_surface.topography_set.order_by("name").first()
+    topo = imported_surface.measurements.order_by("name").first()
 
     # Reset cached state so the inspection recomputes everything from the raw
     # data file: metadata, bandwidth, thumbnail, deepzoom and squeezed data.
-    topo.task_state = Topography.NOTRUN
+    topo.task_state = Measurement.NOTRUN
     topo.data_source = None  # forces first-read metadata population
     topo.datafile_format = None
     topo.squeezed_datafile = None
@@ -68,14 +68,14 @@ def test_full_inspection_via_task_runner(imported_surface):
 
     # Drive the task runner synchronously. ``apply()`` runs the task in-process
     # with a real request context, going through TaskStateModel.run_task ->
-    # Topography.task_worker -> refresh_cache (thumbnail / deepzoom / squeezed).
-    ct = ContentType.objects.get_for_model(Topography)
+    # Measurement.task_worker -> refresh_cache (thumbnail / deepzoom / squeezed).
+    ct = ContentType.objects.get_for_model(Measurement)
     task_dispatch.apply(args=[ct.id, topo.id])
 
     topo.refresh_from_db()
 
     # The task runner drove the result to SUCCESS ...
-    assert topo.task_state == Topography.SUCCESS
+    assert topo.task_state == Measurement.SUCCESS
     # ... and refresh_cache repopulated the cached metadata ...
     assert topo.datafile_format is not None
     assert topo.channel_names

--- a/tests/manager/test_containers.py
+++ b/tests/manager/test_containers.py
@@ -13,7 +13,7 @@ from notifications.models import Notification
 import topobank
 from topobank.manager.export_zip import export_container_zip
 from topobank.manager.import_zip import import_container_zip, load_container_metadata
-from topobank.manager.models import Surface, Topography
+from topobank.manager.models import Surface, Measurement
 from topobank.testing.factories import (
     PropertyFactory,
     SurfaceFactory,
@@ -36,7 +36,7 @@ def test_surface_container(example_authors):
         }
     }
     has_undefined_data = False
-    fill_undefined_data_mode = Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING
+    fill_undefined_data_mode = Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING
 
     user = UserFactory()
     tag1 = TagFactory(name="apple")
@@ -104,7 +104,7 @@ def test_surface_container(example_authors):
             assert meta_surfaces[surf_idx]["created_by"].get("orcid") == surf.created_by.orcid_id
             assert (
                 len(meta_surfaces[surf_idx]["topographies"])
-                == surf.topography_set.count()
+                == surf.measurements.count()
             )
 
         # check some tags
@@ -166,7 +166,7 @@ def test_import():
     ).id
     surface = Surface.objects.get(id=surface_id)
     assert surface.name == "Self-affine synthetic surface"
-    assert surface.topography_set.count() == 3
+    assert surface.measurements.count() == 3
     assert surface.description.startswith(
         "This surface contains virtual measurements taken"
     )

--- a/tests/manager/test_custodian.py
+++ b/tests/manager/test_custodian.py
@@ -6,7 +6,7 @@ import pytest
 from django.utils import timezone
 
 from topobank.manager.custodian import periodic_cleanup
-from topobank.manager.models import Surface, Topography
+from topobank.manager.models import Surface, Measurement
 from topobank.testing.factories import SurfaceFactory, Topography2DFactory
 
 
@@ -58,11 +58,11 @@ def test_periodic_cleanup_deletes_old_marked_topography():
     surface = SurfaceFactory()
     topo = Topography2DFactory(surface=surface)
     old = timezone.now() - datetime.timedelta(days=8)
-    Topography.all_objects.filter(pk=topo.pk).update(deletion_time=old)
+    Measurement.all_objects.filter(pk=topo.pk).update(deletion_time=old)
 
     periodic_cleanup()
 
-    assert not Topography.all_objects.filter(pk=topo.pk).exists()
+    assert not Measurement.all_objects.filter(pk=topo.pk).exists()
 
 
 @pytest.mark.django_db

--- a/tests/manager/test_deepzoom.py
+++ b/tests/manager/test_deepzoom.py
@@ -13,7 +13,7 @@ def test_deepzoom_creation_fails(mocker):
     assert topo.deepzoom is not None
 
     mocker.patch(
-        "topobank.manager.models.Topography._make_deepzoom",
+        "topobank.manager.models.Measurement._make_deepzoom",
         side_effect=Exception("Test exception"),
     )
     topo.refresh_cache()
@@ -27,7 +27,7 @@ def test_missing_thumbnail_is_logged_but_not_fatal(mocker, caplog):
     topo = Topography2DFactory(size_x=1, size_y=1)
 
     mocker.patch(
-        "topobank.manager.models.Topography._make_thumbnail",
+        "topobank.manager.models.Measurement._make_thumbnail",
         side_effect=Exception("Test exception"),
     )
 

--- a/tests/manager/test_import_datasets.py
+++ b/tests/manager/test_import_datasets.py
@@ -51,7 +51,7 @@ def test_import_datasets_creates_surface_with_data(container_archive):
     surfaces = Surface.objects.filter(created_by=importer)
     assert surfaces.count() == 1
     surface = surfaces.get()
-    assert surface.topography_set.count() == 1
+    assert surface.measurements.count() == 1
     # The import records its provenance in the description.
     assert "Imported from file" in surface.description
     # Both the categorical and the numerical property were imported.

--- a/tests/manager/test_incomplete_metadata.py
+++ b/tests/manager/test_incomplete_metadata.py
@@ -13,7 +13,7 @@ import types
 import pytest
 from django.test import override_settings
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.taskapp.models import IncompleteMetadataError, TaskStateModel
 from topobank.testing.factories import ManifestFactory, SurfaceFactory
 
@@ -27,9 +27,9 @@ UNSUPPORTED_DATAFILE = "dummy.txt"
 
 
 def _make_topography(surface, filename):
-    """Create a fresh, uninspected Topography backed by the given fixture file."""
+    """Create a fresh, uninspected Measurement backed by the given fixture file."""
     datafile = ManifestFactory(filename=filename, permissions=surface.permissions)
-    topo = Topography(
+    topo = Measurement(
         surface=surface,
         created_by=surface.created_by,
         permissions=surface.permissions,

--- a/tests/manager/test_models.py
+++ b/tests/manager/test_models.py
@@ -13,7 +13,7 @@ from notifications.models import Notification
 from notifications.signals import notify
 from numpy.testing import assert_allclose
 
-from topobank.manager.models import Surface, Tag, Topography
+from topobank.manager.models import Surface, Tag, Measurement
 from topobank.testing.factories import (
     SurfaceFactory,
     Topography1DFactory,
@@ -26,20 +26,20 @@ PermissionSet = apps.get_model('authorization', 'PermissionSet')
 
 @pytest.mark.django_db
 def test_topography_name(two_topos):
-    topos = Topography.objects.all().order_by("name")
+    topos = Measurement.objects.all().order_by("name")
     assert [t.name for t in topos] == ["Example 3 - ZSensor", "Example 4 - Default"]
 
 
 @pytest.mark.django_db
 def test_topography_has_periodic_flag(two_topos):
-    topos = Topography.objects.all().order_by("name")
+    topos = Measurement.objects.all().order_by("name")
     assert not topos[0].is_periodic
     assert not topos[1].is_periodic
 
 
 @pytest.mark.django_db
 def test_topography_has_unit_set(two_topos):
-    topos = Topography.objects.all().order_by("name")
+    topos = Measurement.objects.all().order_by("name")
     assert topos[0].unit == "nm"
     assert topos[1].unit == "m"
 
@@ -69,13 +69,13 @@ def test_topography_instrument_dict():
 @pytest.mark.django_db
 def test_topography_str(two_topos):
     surface = Surface.objects.get(name="Surface 1")
-    topos = Topography.objects.filter(surface=surface).order_by("name")
+    topos = Measurement.objects.filter(surface=surface).order_by("name")
     assert [str(t) for t in topos] == [
         "Measurement 'Example 3 - ZSensor'"
     ]
 
     surface = Surface.objects.get(name="Surface 2")
-    topos = Topography.objects.filter(surface=surface).order_by("name")
+    topos = Measurement.objects.filter(surface=surface).order_by("name")
     assert [str(t) for t in topos] == [
         "Measurement 'Example 4 - Default'"
     ]
@@ -144,7 +144,7 @@ def test_topography_to_dict():
         "is_periodic": is_periodic,
         "tags": tags,
         "instrument": instrument,
-        "fill_undefined_data_mode": Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING,
+        "fill_undefined_data_mode": Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING,
         "has_undefined_data": False,
         "undefined_data_fraction": 0,
     }
@@ -152,7 +152,7 @@ def test_topography_to_dict():
 
 @pytest.mark.django_db
 def test_call_topography_method_multiple_times(two_topos):
-    topo = Topography.objects.get(name="Example 3 - ZSensor")
+    topo = Measurement.objects.get(name="Example 3 - ZSensor")
 
     #
     # coeffs should not change in between calls
@@ -448,23 +448,23 @@ def test_deepcopy_delete_does_not_delete_files(user_bob, handle_usage_statistics
     assert PermissionSet.objects.count() == 1
 
     surface_copy = surface.deepcopy()
-    assert surface.topography_set.all().first().datafile
-    assert surface_copy.topography_set.all().first().datafile
+    assert surface.measurements.all().first().datafile
+    assert surface_copy.measurements.all().first().datafile
 
     assert PermissionSet.objects.count() == 2
 
     topo.delete()
 
     # Not topography left for surface but one left for surface_copy
-    assert surface.topography_set.count() == 0
-    assert surface_copy.topography_set.all().first().datafile
+    assert surface.measurements.count() == 0
+    assert surface_copy.measurements.all().first().datafile
 
     # Both surfaces are still there so we should have two permission sets
     assert PermissionSet.objects.count() == 2
 
     surface.delete()
     assert PermissionSet.objects.count() == 1
-    assert surface_copy.topography_set.all().first().datafile
+    assert surface_copy.measurements.all().first().datafile
 
 
 @pytest.mark.django_db
@@ -519,8 +519,8 @@ def test_deepcopy_copies_attachments(user_bob, handle_usage_statistics):
     assert PermissionSet.objects.count() == 1
 
     surface_copy = surface.deepcopy()
-    assert surface.topography_set.all().first().datafile
-    assert surface_copy.topography_set.all().first().datafile
+    assert surface.measurements.all().first().datafile
+    assert surface_copy.measurements.all().first().datafile
 
     assert PermissionSet.objects.count() == 2
 
@@ -532,8 +532,8 @@ def test_deepcopy_copies_attachments(user_bob, handle_usage_statistics):
     assert file.id != file_copy.id
     assert file.file.name != file_copy.file.name
 
-    topo = surface.topography_set.all().first()
-    topo_copy = surface_copy.topography_set.all().first()
+    topo = surface.measurements.all().first()
+    topo_copy = surface_copy.measurements.all().first()
 
     assert topo.id != topo_copy.id
     assert topo.attachments.id != topo_copy.attachments.id

--- a/tests/manager/test_search_vector.py
+++ b/tests/manager/test_search_vector.py
@@ -11,7 +11,7 @@ re-index.
 import pytest
 from django.contrib.postgres.search import SearchQuery
 
-from topobank.manager.models import Surface, Topography
+from topobank.manager.models import Surface, Measurement
 from topobank.testing.factories import (
     SurfaceFactory,
     TagFactory,
@@ -98,7 +98,7 @@ def test_a_save_that_touches_no_searchable_field_does_not_reindex(mocker):
     topography.save(update_fields=["detrend_mode"])
 
     reindex.assert_not_called()
-    assert Topography.objects.get(pk=topography.pk).detrend_mode == "height"
+    assert Measurement.objects.get(pk=topography.pk).detrend_mode == "height"
 
 
 @pytest.mark.django_db

--- a/tests/manager/test_topography_task_state.py
+++ b/tests/manager/test_topography_task_state.py
@@ -1,5 +1,5 @@
 """
-Tests for issue #1342: Topography.save() with a restricted update_fields must
+Tests for issue #1342: Measurement.save() with a restricted update_fields must
 still persist the pending task state that run_task sets in memory.
 
 Otherwise a recompute is dispatched while the DB keeps task_state=SUCCESS
@@ -10,23 +10,23 @@ concurrent edit from double-dispatching.
 
 import pytest
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import Topography2DFactory
 
 
 @pytest.mark.django_db
 def test_save_update_fields_persists_pending_state():
     topo = Topography2DFactory()
-    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    Measurement.objects.filter(pk=topo.pk).update(task_state=Measurement.SUCCESS)
     topo.refresh_from_db()
-    assert topo.task_state == Topography.SUCCESS
+    assert topo.task_state == Measurement.SUCCESS
 
     # A significant field changes, saved with a restricted update_fields.
     topo.size_x = topo.size_x + 1
     topo.save(update_fields=["size_x"])
 
-    reloaded = Topography.objects.get(pk=topo.pk)
-    assert reloaded.task_state == Topography.PENDING  # pending state persisted
+    reloaded = Measurement.objects.get(pk=topo.pk)
+    assert reloaded.task_state == Measurement.PENDING  # pending state persisted
     assert reloaded.size_x == topo.size_x  # the requested field still saved
 
 
@@ -35,13 +35,13 @@ def test_save_update_fields_no_change_keeps_state():
     """A save with update_fields that does not touch a significant field must
     not spuriously flip the state to pending."""
     topo = Topography2DFactory()
-    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    Measurement.objects.filter(pk=topo.pk).update(task_state=Measurement.SUCCESS)
     topo.refresh_from_db()
 
     topo.name = "renamed"  # not a significant field
     topo.save(update_fields=["name"])
 
-    assert Topography.objects.get(pk=topo.pk).task_state == Topography.SUCCESS
+    assert Measurement.objects.get(pk=topo.pk).task_state == Measurement.SUCCESS
 
 
 @pytest.mark.django_db
@@ -49,20 +49,20 @@ def test_persisted_pending_state_enables_inflight_guard():
     """Once the pending state is persisted, a concurrent handle sees it and is
     guarded from re-dispatching (run_task skips set_pending_state)."""
     topo = Topography2DFactory()
-    Topography.objects.filter(pk=topo.pk).update(task_state=Topography.SUCCESS)
+    Measurement.objects.filter(pk=topo.pk).update(task_state=Measurement.SUCCESS)
     topo.refresh_from_db()
 
     topo.size_x += 1
     topo.save(update_fields=["size_x"])
-    assert Topography.objects.get(pk=topo.pk).task_state == Topography.PENDING
-    submission_before = Topography.objects.get(pk=topo.pk).task_submission_time
+    assert Measurement.objects.get(pk=topo.pk).task_state == Measurement.PENDING
+    submission_before = Measurement.objects.get(pk=topo.pk).task_submission_time
 
     # A separate handle (concurrent worker) sees PENDING; its save must not
     # reset the submission time, i.e. no second dispatch is set up.
-    concurrent = Topography.objects.get(pk=topo.pk)
+    concurrent = Measurement.objects.get(pk=topo.pk)
     concurrent.size_x += 1
     concurrent.save(update_fields=["size_x"])
 
     assert (
-        Topography.objects.get(pk=topo.pk).task_submission_time == submission_before
+        Measurement.objects.get(pk=topo.pk).task_submission_time == submission_before
     )

--- a/tests/manager/test_undefined_data.py
+++ b/tests/manager/test_undefined_data.py
@@ -2,14 +2,14 @@
 Tests for how much of a measurement is undefined.
 
 A measurement can carry data points that hold no value, because the instrument
-could not resolve them. `Topography.has_undefined_data` records that this is the
-case and `Topography.undefined_data_fraction` how much of the data it affects,
+could not resolve them. `Measurement.has_undefined_data` records that this is the
+case and `Measurement.undefined_data_fraction` how much of the data it affects,
 both describing the data as measured rather than as filtered for display.
 """
 
 import pytest
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.testing.factories import ManifestFactory, SurfaceFactory
 
 # A bare 10x10 matrix of numbers with seven of its hundred entries written as
@@ -24,7 +24,7 @@ TOTAL_POINTS = 100
 def _make_topography(surface, filename, **kwargs):
     """Create and inspect a measurement backed by the given fixture file."""
     datafile = ManifestFactory(filename=filename, permissions=surface.permissions)
-    topo = Topography(
+    topo = Measurement(
         surface=surface,
         created_by=surface.created_by,
         permissions=surface.permissions,
@@ -68,7 +68,7 @@ def test_reports_the_measured_data_even_when_filling_is_enabled(surface):
     topo = _make_topography(
         surface,
         UNDEFINED_DATAFILE,
-        fill_undefined_data_mode=Topography.FILL_UNDEFINED_DATA_MODE_HARMONIC,
+        fill_undefined_data_mode=Measurement.FILL_UNDEFINED_DATA_MODE_HARMONIC,
     )
     assert topo.has_undefined_data is True
     assert topo.undefined_data_fraction == pytest.approx(UNDEFINED_POINTS / TOTAL_POINTS)
@@ -78,7 +78,7 @@ def test_fraction_is_unknown_before_inspection(surface):
     datafile = ManifestFactory(
         filename=UNDEFINED_DATAFILE, permissions=surface.permissions
     )
-    topo = Topography(
+    topo = Measurement(
         surface=surface,
         created_by=surface.created_by,
         permissions=surface.permissions,

--- a/tests/manager/test_utils.py
+++ b/tests/manager/test_utils.py
@@ -5,7 +5,7 @@ and other things in topobank.manager.utils
 
 import pytest
 
-from topobank.manager.models import Surface, Topography
+from topobank.manager.models import Surface, Measurement
 from topobank.manager.utils import (
     subjects_from_base64,
     subjects_from_dict,
@@ -18,7 +18,7 @@ from topobank.testing.factories import SurfaceFactory, UserFactory
 
 @pytest.mark.django_db
 def test_subjects_to_dict(user_three_topographies_three_surfaces_three_tags):
-    topo1, topo2, topo3 = Topography.objects.all()
+    topo1, topo2, topo3 = Measurement.objects.all()
     surf1, surf2, surf3 = Surface.objects.all()
     assert subjects_from_dict(subjects_to_dict([topo1, topo2, surf3])) == [
         topo1,
@@ -29,7 +29,7 @@ def test_subjects_to_dict(user_three_topographies_three_surfaces_three_tags):
 
 @pytest.mark.django_db
 def test_subjects_to_url(user_three_topographies_three_surfaces_three_tags):
-    topo1, topo2, topo3 = Topography.objects.all()
+    topo1, topo2, topo3 = Measurement.objects.all()
     surf1, surf2, surf3 = Surface.objects.all()
     assert subjects_from_base64(subjects_to_base64([topo1, topo2, surf3])) == [
         topo1,

--- a/tests/taskapp/test_perform.py
+++ b/tests/taskapp/test_perform.py
@@ -2,20 +2,20 @@ import pytest
 
 from topobank.analysis.models import WorkflowResult
 from topobank.analysis.tasks import get_current_configuration, perform_analysis
-from topobank.manager.models import Topography
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.manager.models import Measurement
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 
 @pytest.mark.django_db
 def test_perform_analysis(
     two_topos, test_workflow, settings
 ):
-    topo = Topography.objects.first()  # doesn't matter
+    topo = Measurement.objects.first()  # doesn't matter
 
     func_kwargs = dict(a=1, b="hamming")
 
-    analysis = TopographyAnalysisFactory.create(
-        subject_topography=topo,
+    analysis = MeasurementAnalysisFactory.create(
+        subject_measurement=topo,
         workflow_name=test_workflow.name,
         kwargs=func_kwargs,
         result=None,
@@ -47,9 +47,9 @@ def test_perform_analysis(
         ("numpy", "numpy.version.full_version", "BSD 3-Clause", "ghi"),
     ]
 
-    topo2 = Topography.objects.last()
-    analysis2 = TopographyAnalysisFactory.create(
-        subject_topography=topo2,
+    topo2 = Measurement.objects.last()
+    analysis2 = MeasurementAnalysisFactory.create(
+        subject_measurement=topo2,
         workflow_name=test_workflow.name,
         kwargs=func_kwargs,
         result=None,

--- a/tests/taskapp/test_run_task_guard.py
+++ b/tests/taskapp/test_run_task_guard.py
@@ -8,7 +8,7 @@ causing concurrent ``refresh_cache`` executions on the same measurement.
 import pytest
 from django.core.management import call_command
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.taskapp.models import TaskStateModel
 from topobank.taskapp.utils import run_task
 from topobank.testing.factories import Topography1DFactory
@@ -16,7 +16,7 @@ from topobank.testing.factories import Topography1DFactory
 
 def _set_state(topo, state, **extra):
     """Force task_state (and optional extra fields) directly in the DB."""
-    Topography.objects.filter(pk=topo.pk).update(task_state=state, **extra)
+    Measurement.objects.filter(pk=topo.pk).update(task_state=state, **extra)
     topo.refresh_from_db()
 
 

--- a/tests/taskapp/test_set_pending_state.py
+++ b/tests/taskapp/test_set_pending_state.py
@@ -12,7 +12,7 @@ import uuid
 import pytest
 
 from topobank.analysis.models import WorkflowResult
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 START_TIME = datetime.datetime(2018, 1, 1, 12, tzinfo=datetime.timezone.utc)
 END_TIME = datetime.datetime(2018, 1, 1, 13, tzinfo=datetime.timezone.utc)
@@ -24,7 +24,7 @@ class TestSetPendingState:
 
     def test_clears_timestamps(self, test_workflow):
         """Both run timestamps are reset so the re-pended row looks fresh."""
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_start_time=START_TIME,
             task_end_time=END_TIME,
@@ -43,7 +43,7 @@ class TestSetPendingState:
 
     def test_task_duration_is_none_after_repend(self, test_workflow):
         """duration() must not report a stale value from the previous run."""
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_start_time=START_TIME,
             task_end_time=END_TIME,
@@ -58,7 +58,7 @@ class TestSetPendingState:
 
     def test_resets_state_and_clears_error_fields(self, test_workflow):
         """The remaining bookkeeping fields are reset alongside the timestamps."""
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.FAILURE,
             task_id=str(uuid.uuid4()),
             task_error="boom",
@@ -77,7 +77,7 @@ class TestSetPendingState:
 
     def test_autosave_false_does_not_persist(self, test_workflow):
         """With autosave=False the in-memory row is reset but the DB is untouched."""
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_start_time=START_TIME,
             task_end_time=END_TIME,

--- a/tests/taskapp/test_signal_handlers.py
+++ b/tests/taskapp/test_signal_handlers.py
@@ -15,13 +15,13 @@ from celery.signals import task_failure, task_revoked, task_success
 from django.utils import timezone
 
 from topobank.analysis.models import WorkflowResult
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.manager.zip_model import ZipContainer
 from topobank.taskapp.celeryapp import CeleryAppConfig
 from topobank.testing.factories import (
     SurfaceFactory,
     Topography2DFactory,
-    TopographyAnalysisFactory,
+    MeasurementAnalysisFactory,
     UserFactory,
 )
 
@@ -48,7 +48,7 @@ class TestTaskFailureSignal:
     def test_updates_state_on_worker_crash(self, app_config, mock_now, test_workflow):
         """Test that task failure updates state from STARTED to FAILURE."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -72,7 +72,7 @@ class TestTaskFailureSignal:
     def test_records_exception_message_and_traceback(self, app_config, mock_now, test_workflow):
         """Test that exception details are properly recorded."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -96,7 +96,7 @@ class TestTaskFailureSignal:
         """Test that traceback objects are properly formatted as strings."""
         import traceback as tb
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -123,7 +123,7 @@ class TestTaskFailureSignal:
     def test_sets_task_end_time(self, app_config, mock_now, test_workflow):
         """Test that task_end_time is set when task fails."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             task_end_time=None,
@@ -143,7 +143,7 @@ class TestTaskFailureSignal:
     def test_respects_success_terminal_state(self, app_config, mocker, test_workflow):
         """Test that SUCCESS state is not overridden by failure signal."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -168,7 +168,7 @@ class TestTaskFailureSignal:
         """Test that FAILURE state is not overridden by another failure signal."""
         task_id = str(uuid.uuid4())
         original_error = "Original error"
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.FAILURE,
             task_id=task_id,
             task_error=original_error,
@@ -207,10 +207,10 @@ class TestTaskFailureSignal:
         assert mock_log.debug.called
 
     def test_handles_all_model_types(self, app_config, mock_now, test_workflow):
-        """Test that signal handler works for WorkflowResult, Topography, and ZipContainer."""
+        """Test that signal handler works for WorkflowResult, Measurement, and ZipContainer."""
         # Test WorkflowResult
         task_id_1 = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id_1,
             workflow_name=test_workflow.name,
@@ -226,13 +226,13 @@ class TestTaskFailureSignal:
         analysis.refresh_from_db()
         assert analysis.task_state == WorkflowResult.FAILURE
 
-        # Test Topography
+        # Test Measurement
         task_id_2 = str(uuid.uuid4())
         user = UserFactory()
         surface = SurfaceFactory(created_by=user)
         topo = Topography2DFactory(
             surface=surface,
-            task_state=Topography.STARTED,
+            task_state=Measurement.STARTED,
             task_id=task_id_2,
         )
 
@@ -244,7 +244,7 @@ class TestTaskFailureSignal:
         )
 
         topo.refresh_from_db()
-        assert topo.task_state == Topography.FAILURE
+        assert topo.task_state == Measurement.FAILURE
 
         # Test ZipContainer
         task_id_3 = str(uuid.uuid4())
@@ -270,7 +270,7 @@ class TestTaskFailureSignal:
     def test_signal_handler_exception_handling(self, app_config, mocker, test_workflow):
         """Test that signal handler doesn't crash even if internal error occurs."""
         task_id = str(uuid.uuid4())
-        TopographyAnalysisFactory(
+        MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -299,7 +299,7 @@ class TestTaskRevokedSignal:
     def test_updates_state_on_cancellation(self, app_config, mock_now, test_workflow):
         """Test that task revocation updates state to FAILURE."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -325,7 +325,7 @@ class TestTaskRevokedSignal:
     def test_records_terminated_flag(self, app_config, mock_now, test_workflow):
         """Test that terminated flag is recorded in error message."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -349,7 +349,7 @@ class TestTaskRevokedSignal:
     def test_records_expired_flag(self, app_config, mock_now, test_workflow):
         """Test that expired flag is recorded in error message."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -373,7 +373,7 @@ class TestTaskRevokedSignal:
     def test_sets_task_end_time(self, app_config, mock_now, test_workflow):
         """Test that task_end_time is set when task is revoked."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             task_end_time=None,
@@ -397,7 +397,7 @@ class TestTaskRevokedSignal:
     def test_respects_terminal_states(self, app_config, mocker, test_workflow):
         """Test that terminal states are not overridden."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -442,7 +442,7 @@ class TestTaskRevokedSignal:
     def test_signal_handler_exception_handling(self, app_config, mocker, test_workflow):
         """Test that signal handler doesn't crash even if internal error occurs."""
         task_id = str(uuid.uuid4())
-        TopographyAnalysisFactory(
+        MeasurementAnalysisFactory(
             task_state=WorkflowResult.STARTED,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -474,7 +474,7 @@ class TestTaskSuccessSignal:
     def test_logs_warning_on_state_mismatch(self, app_config, mocker, test_workflow):
         """Test that warning is logged when Celery reports SUCCESS but DB shows FAILURE."""
         task_id = str(uuid.uuid4())
-        TopographyAnalysisFactory(
+        MeasurementAnalysisFactory(
             task_state=WorkflowResult.FAILURE,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -500,7 +500,7 @@ class TestTaskSuccessSignal:
     def test_no_action_when_states_match(self, app_config, mocker, test_workflow):
         """Test that no action is taken when states match."""
         task_id = str(uuid.uuid4())
-        TopographyAnalysisFactory(
+        MeasurementAnalysisFactory(
             task_state=WorkflowResult.SUCCESS,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -539,7 +539,7 @@ class TestTaskSuccessSignal:
     def test_signal_handler_exception_handling(self, app_config, mocker, test_workflow):
         """Test that signal handler doesn't crash even if internal error occurs."""
         task_id = str(uuid.uuid4())
-        TopographyAnalysisFactory(
+        MeasurementAnalysisFactory(
             task_state=WorkflowResult.FAILURE,
             task_id=task_id,
             workflow_name=test_workflow.name,
@@ -575,7 +575,7 @@ class TestFindTaskInstance:
     def test_finds_workflow_result(self, app_config, test_workflow):
         """Test that WorkflowResult can be found by task_id."""
         task_id = str(uuid.uuid4())
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_id=task_id,
             workflow_name=test_workflow.name,
         )
@@ -587,7 +587,7 @@ class TestFindTaskInstance:
         assert isinstance(found, WorkflowResult)
 
     def test_finds_topography(self, app_config):
-        """Test that Topography can be found by task_id."""
+        """Test that Measurement can be found by task_id."""
         task_id = str(uuid.uuid4())
         user = UserFactory()
         surface = SurfaceFactory(created_by=user)
@@ -600,7 +600,7 @@ class TestFindTaskInstance:
 
         assert found is not None
         assert found.id == topo.id
-        assert isinstance(found, Topography)
+        assert isinstance(found, Measurement)
 
     def test_finds_zip_container(self, app_config):
         """Test that ZipContainer can be found by task_id."""
@@ -630,12 +630,12 @@ class TestFindTaskInstance:
         task_id = str(uuid.uuid4())
 
         # Create WorkflowResult with this task_id
-        analysis = TopographyAnalysisFactory(
+        analysis = MeasurementAnalysisFactory(
             task_id=task_id,
             workflow_name=test_workflow.name,
         )
 
-        # The helper searches in order: WorkflowResult, Topography, ZipContainer
+        # The helper searches in order: WorkflowResult, Measurement, ZipContainer
         # So it should find WorkflowResult first
         found = app_config._find_task_instance(task_id)
 

--- a/tests/taskapp/test_submit.py
+++ b/tests/taskapp/test_submit.py
@@ -2,7 +2,7 @@ import pydantic
 import pytest
 
 from topobank.analysis.models import WorkflowResult
-from topobank.testing.factories import Topography1DFactory, TopographyAnalysisFactory
+from topobank.testing.factories import Topography1DFactory, MeasurementAnalysisFactory
 
 
 @pytest.mark.django_db
@@ -56,14 +56,14 @@ def test_different_kwargs(mocker, test_workflow):
     topo = Topography1DFactory()
     user = topo.created_by
 
-    a1 = TopographyAnalysisFactory(
-        subject_topography=topo,
+    a1 = MeasurementAnalysisFactory(
+        subject_measurement=topo,
         workflow_name=test_workflow.name,
         kwargs=dict(a=9, b=19),
         user=user,
     )
-    a2 = TopographyAnalysisFactory(
-        subject_topography=topo,
+    a2 = MeasurementAnalysisFactory(
+        subject_measurement=topo,
         workflow_name=test_workflow.name,
         kwargs=dict(a=29, b=39),
         user=user,
@@ -76,7 +76,7 @@ def test_different_kwargs(mocker, test_workflow):
     #
     assert (
         WorkflowResult.objects.filter(
-            subject_topography=topo, workflow_name=test_workflow.name
+            subject_measurement=topo, workflow_name=test_workflow.name
         ).count()
         == 3
     )
@@ -85,7 +85,7 @@ def test_different_kwargs(mocker, test_workflow):
     # Only one analysis is marked for user 'user'
     #
     analyses = WorkflowResult.objects.filter(
-        subject_topography=topo,
+        subject_measurement=topo,
         workflow_name=test_workflow.name,
         permissions__user_permissions__user=user,
     )

--- a/tests/taskapp/test_task_state.py
+++ b/tests/taskapp/test_task_state.py
@@ -24,8 +24,8 @@ from SurfaceTopography.Exceptions import CannotDetectFileFormat
 
 from topobank.analysis.models import WorkflowResult
 from topobank.analysis.tasks import perform_analysis
-from topobank.manager.models import Topography
-from topobank.testing.factories import TopographyAnalysisFactory
+from topobank.manager.models import Measurement
+from topobank.testing.factories import MeasurementAnalysisFactory
 
 # Importing this module runs the @register_implementation decorators that make
 # the "topobank.testing.test" workflow available. Without it the end-to-end
@@ -45,7 +45,7 @@ def _make_analysis(test_workflow, **overrides):
         result=None,
     )
     params.update(overrides)
-    return TopographyAnalysisFactory.create(**params)
+    return MeasurementAnalysisFactory.create(**params)
 
 
 # ---------------------------------------------------------------------------
@@ -164,9 +164,9 @@ def test_task_duration(test_workflow):
 
 @pytest.mark.django_db
 def test_eager_execution_reaches_success(two_topos, test_workflow):
-    topo = Topography.objects.first()
-    analysis = TopographyAnalysisFactory.create(
-        subject_topography=topo,
+    topo = Measurement.objects.first()
+    analysis = MeasurementAnalysisFactory.create(
+        subject_measurement=topo,
         workflow_name=test_workflow.name,
         kwargs=dict(a=1, b="hamming"),
         result=None,

--- a/topobank/analysis/admin.py
+++ b/topobank/analysis/admin.py
@@ -14,12 +14,12 @@ class SubjectTypeFilter(admin.SimpleListFilter):
         return (
             ("tag", _("Tag")),
             ("surface", _("Surface")),
-            ("topography", _("Measurement")),
+            ("measurement", _("Measurement")),
         )
 
     def queryset(self, _request, queryset):
         value = self.value()
-        if value in ("tag", "surface", "topography"):
+        if value in ("tag", "surface", "measurement"):
             filter_key = f"subject_{value}__isnull"
             return queryset.filter(**{filter_key: False})
         return queryset
@@ -46,7 +46,7 @@ class WorkflowResultAdmin(admin.ModelAdmin):
 
     @admin.display(description="Subject Type")
     def subject_type(self, obj):
-        """Display the type of the subject (tag, surface, or topography)."""
+        """Display the type of the subject (tag, surface, or measurement)."""
         return obj.subject.__class__.__name__
 
     @admin.action(description="Resubmit selected workflow results")

--- a/topobank/analysis/admin.py
+++ b/topobank/analysis/admin.py
@@ -5,7 +5,7 @@ from .models import WorkflowResult
 
 
 class SubjectTypeFilter(admin.SimpleListFilter):
-    """Filter for WorkflowResult subject types (Tag, Surface, or Topography)."""
+    """Filter for WorkflowResult subject types (Tag, Surface, or Measurement)."""
 
     title = _("Subject Type")
     parameter_name = "subject_type"
@@ -14,7 +14,7 @@ class SubjectTypeFilter(admin.SimpleListFilter):
         return (
             ("tag", _("Tag")),
             ("surface", _("Surface")),
-            ("topography", _("Topography")),
+            ("topography", _("Measurement")),
         )
 
     def queryset(self, _request, queryset):

--- a/topobank/analysis/controller.py
+++ b/topobank/analysis/controller.py
@@ -19,7 +19,7 @@ class AnalysisController:
     """Retrieve and toggle status of analyses"""
 
     queryset = WorkflowResult.objects.all().select_related(
-        "subject_topography",
+        "subject_measurement",
         "subject_surface",
         "subject_tag",
     )
@@ -42,7 +42,7 @@ class AnalysisController:
         ----------
         user : topobank.manager.models.User
             Currently logged-in user.
-        subjects : list of Tag, Topography or Surface, optional
+        subjects : list of Tag, Measurement or Surface, optional
             Subjects for which to filter analyses. (Default: None)
         workflow : Workflow, optional
             Workflow function object. (Default: None)
@@ -239,13 +239,13 @@ class AnalysisController:
         qs = (
             self.queryset.filter(query)
             .order_by(
-                "subject_topography_id",
+                "subject_measurement_id",
                 "subject_surface_id",
                 "subject_tag_id",
                 "-task_start_time",
             )
             .distinct(
-                "subject_topography_id",
+                "subject_measurement_id",
                 "subject_surface_id",
                 "subject_tag_id",
             )

--- a/topobank/analysis/custodian.py
+++ b/topobank/analysis/custodian.py
@@ -27,7 +27,7 @@ def periodic_cleanup():
             name__isnull=True,
         )
         .filter(
-            Q(subject_topography__isnull=False)
+            Q(subject_measurement__isnull=False)
             | Q(subject_surface__isnull=False)
             | Q(subject_tag__isnull=False)
             | Q(surfaces__isnull=False)

--- a/topobank/analysis/legacy/workflows.py
+++ b/topobank/analysis/legacy/workflows.py
@@ -15,7 +15,7 @@ import pydantic
 from muTimer import Timer
 from pydantic import field_validator
 
-from ...manager.models import Surface, Tag, Topography
+from ...manager.models import Surface, Tag, Measurement
 from ...supplib.dict import SplitDictionaryHere
 from ..models import Workflow
 from ..outputs import get_outputs_schema
@@ -189,7 +189,7 @@ def make_alert_entry(
 @dataclass
 class WorkflowDefinition:
     # We don't allow tags as dependencies
-    subject: Union[Surface, Topography] = None
+    subject: Union[Surface, Measurement] = None
 
     # Analysis function
     function: Workflow = None
@@ -272,8 +272,8 @@ class WorkflowImplementation:
         elif n == 1:
             if self.has_implementation(Surface):
                 impl = self.get_implementation(Surface)
-            elif self.has_implementation(Topography):
-                impl = self.get_implementation(Topography)
+            elif self.has_implementation(Measurement):
+                impl = self.get_implementation(Measurement)
             else:
                 raise WorkflowNotImplementedException(self.Meta.name, Surface)
         else:
@@ -374,9 +374,9 @@ class WorkflowImplementation:
         # More than one surface → use Tag-based dependency function
         if n > 1:
             dep_key = Tag
-        # Exactly one surface → prefer Surface, fall back to Topography
+        # Exactly one surface → prefer Surface, fall back to Measurement
         elif n == 1:
-            dep_key = Surface if Surface in dependencies else Topography
+            dep_key = Surface if Surface in dependencies else Measurement
         else:
             return []
 

--- a/topobank/analysis/migrations/0066_rename_subject_topography_measurement.py
+++ b/topobank/analysis/migrations/0066_rename_subject_topography_measurement.py
@@ -1,0 +1,55 @@
+"""
+Rename `WorkflowResult.subject_topography` to `subject_measurement`.
+
+This is a rename, not a drop-and-add: the column holds the subject of every
+measurement-level analysis ever computed.
+
+The subject-type tag stored inside `subject_hash` deliberately keeps saying
+"topography". It is opaque, never shown to users, and rewriting it would mean
+recomputing the hash of every row for no benefit (see
+`WorkflowResult.update_subject_hash`).
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+import topobank.analysis.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analysis", "0065_resultzipcontainer"),
+        # The target model must have been renamed first.
+        ("manager", "0084_rename_topography_measurement"),
+    ]
+
+    operations = [
+        # The index references the field, so it goes first and is recreated after.
+        migrations.RemoveIndex(
+            model_name="workflowresult", name="result_func_topo_time_idx"
+        ),
+        migrations.RenameField(
+            model_name="workflowresult",
+            old_name="subject_topography",
+            new_name="subject_measurement",
+        ),
+        migrations.AlterField(
+            model_name="workflowresult",
+            name="subject_measurement",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=topobank.analysis.models.cascade_or_set_null,
+                related_name="workflow_results",
+                to="manager.measurement",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="workflowresult",
+            index=models.Index(
+                fields=["workflow_name", "subject_measurement", "-task_start_time"],
+                name="result_func_topo_time_idx",
+            ),
+        ),
+    ]

--- a/topobank/analysis/models.py
+++ b/topobank/analysis/models.py
@@ -21,7 +21,7 @@ from ..authorization import get_permission_model
 from ..authorization.mixins import PermissionMixin
 from ..authorization.models import AuthorizedManager, ViewEditFull
 from ..files.models import Manifest, ManifestSet
-from ..manager.models import Surface, Tag, Topography
+from ..manager.models import Surface, Tag, Measurement
 from ..supplib.db import advisory_lock
 from ..supplib.dict import load_split_dict, store_split_dict
 from ..taskapp.models import Configuration, TaskStateModel
@@ -75,8 +75,8 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
     workflow_name = models.CharField(max_length=255, null=True, db_index=True)
 
     # Definition of the subject
-    subject_topography = models.ForeignKey(
-        Topography,
+    subject_measurement = models.ForeignKey(
+        Measurement,
         null=True,
         blank=True,
         on_delete=cascade_or_set_null,
@@ -192,7 +192,7 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
             ),
             # Composite indexes for filtering by workflow_name + subject and ordering by time
             models.Index(
-                fields=["workflow_name", "subject_topography", "-task_start_time"],
+                fields=["workflow_name", "subject_measurement", "-task_start_time"],
                 name="result_func_topo_time_idx",
             ),
             models.Index(
@@ -246,16 +246,16 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
 
         # Named results are detached from their subject
         if self.name and (
-            self.subject_topography_id is not None
+            self.subject_measurement_id is not None
             or self.subject_surface_id is not None
             or self.subject_tag_id is not None
         ):
-            self.subject_topography = None
+            self.subject_measurement = None
             self.subject_surface = None
             self.subject_tag = None
             if "update_fields" in kwargs and kwargs["update_fields"] is not None:
                 kwargs["update_fields"] = list(kwargs["update_fields"]) + [
-                    "subject_topography",
+                    "subject_measurement",
                     "subject_surface",
                     "subject_tag",
                 ]
@@ -301,17 +301,17 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
     @property
     def subject(self):
         """
-        Return the subject of the WorkflowResult, which can be a Tag, a Topography, or a
+        Return the subject of the WorkflowResult, which can be a Tag, a Measurement, or a
         Surface.
 
         Returns
         -------
-        Tag, Topography, Surface, or QuerySet
+        Tag, Measurement, Surface, or QuerySet
             The subject of the WorkflowResult. For surface-set analyses with a single
             surface, returns that Surface. For multi-surface sets, returns the queryset.
         """
-        if self.subject_topography_id is not None:
-            return self.subject_topography
+        if self.subject_measurement_id is not None:
+            return self.subject_measurement
         elif self.subject_surface_id is not None:
             return self.subject_surface
         elif self.subject_tag_id is not None:
@@ -474,7 +474,7 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
     @property
     def is_topography_related(self) -> bool:
         """Returns True, if the WorkflowResult subject is a topography, else False."""
-        return self.subject_topography_id is not None
+        return self.subject_measurement_id is not None
 
     @property
     def is_surface_related(self) -> bool:
@@ -491,13 +491,13 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         """Build a Q object to filter WorkflowResults for a single subject."""
         if isinstance(subject, Tag):
             return models.Q(subject_tag_id=subject.id)
-        elif isinstance(subject, Topography):
-            return models.Q(subject_topography_id=subject.id)
+        elif isinstance(subject, Measurement):
+            return models.Q(subject_measurement_id=subject.id)
         elif isinstance(subject, Surface):
             return models.Q(subject_surface_id=subject.id)
         else:
             raise ValueError(
-                "`subject` argument must be of type `Tag`, `Topography` or `Surface`, "
+                "`subject` argument must be of type `Tag`, `Measurement` or `Surface`, "
                 f"not {type(subject)}."
             )
 
@@ -510,13 +510,13 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         for subject in subjects:
             if isinstance(subject, Tag):
                 tag_ids.append(subject.id)
-            elif isinstance(subject, Topography):
+            elif isinstance(subject, Measurement):
                 topography_ids.append(subject.id)
             elif isinstance(subject, Surface):
                 surface_ids.append(subject.id)
             else:
                 raise ValueError(
-                    "`subject` argument must be of type `Tag`, `Topography` or `Surface`, "
+                    "`subject` argument must be of type `Tag`, `Measurement` or `Surface`, "
                     f"not {type(subject)}."
                 )
         query = None
@@ -526,7 +526,7 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
             )
             query = q
         if topography_ids:
-            q = models.Q(subject_topography_id__in=topography_ids)
+            q = models.Q(subject_measurement_id__in=topography_ids)
             query = query | q if query else q
         if surface_ids:
             q = models.Q(subject_surface_id__in=surface_ids)
@@ -545,8 +545,11 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         ids = list(self.surfaces.values_list("id", flat=True))
         if ids:
             self.subject_hash = self.compute_subject_hash("surfaces", ids)
-        elif self.subject_topography_id is not None:
-            self.subject_hash = self.compute_subject_hash("topography", [self.subject_topography_id])
+        elif self.subject_measurement_id is not None:
+            # The tag deliberately still reads "topography": it is opaque, never
+            # shown to a user, and changing it would invalidate the hash of every
+            # measurement-level result ever computed.
+            self.subject_hash = self.compute_subject_hash("topography", [self.subject_measurement_id])
         elif self.subject_surface_id is not None:
             self.subject_hash = self.compute_subject_hash("surface", [self.subject_surface_id])
         elif self.subject_tag_id is not None:
@@ -598,14 +601,14 @@ class WorkflowResult(PermissionMixin, TaskStateModel):
         """
         self.name = name
         self.description = description
-        self.subject_topography = None
+        self.subject_measurement = None
         self.subject_surface = None
         self.subject_tag = None
         self.save(
             update_fields=[
                 "name",
                 "description",
-                "subject_topography",
+                "subject_measurement",
                 "subject_surface",
                 "subject_tag",
             ]
@@ -756,7 +759,7 @@ class Workflow:
 
     def eval(self, analysis, **auxiliary_kwargs):
         """
-        First argument is the subject of the WorkflowResult (`Surface`, `Topography` or `Tag`).
+        First argument is the subject of the WorkflowResult (`Surface`, `Measurement` or `Tag`).
         """
         impl = self.implementation
         if impl is None:
@@ -773,14 +776,14 @@ class Workflow:
     def submit(
         self,
         user: settings.AUTH_USER_MODEL,
-        subject: Union[Tag, Surface, Topography],
+        subject: Union[Tag, Surface, Measurement],
         kwargs: dict = None,
         force_submit: bool = False,
     ):
         """
         user : topobank.users.models.User
             Users which should see the WorkflowResult.
-        subject : Tag or Topography or Surface
+        subject : Tag or Measurement or Surface
             Instance which will be subject of the WorkflowResult (first argument of WorkflowResult
             function).
         kwargs : dict, optional
@@ -868,7 +871,7 @@ class Workflow:
     def _submit_new_analysis(
         self,
         user: settings.AUTH_USER_MODEL,
-        subject: Union[Tag, Topography, Surface],
+        subject: Union[Tag, Measurement, Surface],
         kwargs: dict,
     ):
         """
@@ -878,7 +881,7 @@ class Workflow:
         ----------
         user: topobank.users.models.User
             User which should see the WorkflowResult.
-        subject: Tag or Topography or Surface
+        subject: Tag or Measurement or Surface
             Instance which will be subject of the WorkflowResult.
         kwargs: dict
             Keyword arguments for the function which should be saved to database.
@@ -903,8 +906,8 @@ class Workflow:
             if isinstance(subject, Tag):
                 create_kwargs["subject_tag"] = subject
                 create_kwargs["subject_hash"] = WorkflowResult.compute_subject_hash("tag", [subject.id])
-            elif isinstance(subject, Topography):
-                create_kwargs["subject_topography"] = subject
+            elif isinstance(subject, Measurement):
+                create_kwargs["subject_measurement"] = subject
                 create_kwargs["subject_hash"] = WorkflowResult.compute_subject_hash("topography", [subject.id])
             elif isinstance(subject, Surface):
                 create_kwargs["subject_surface"] = subject

--- a/topobank/analysis/signals.py
+++ b/topobank/analysis/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from ..authorization import get_permission_model
-from ..manager.models import Topography, post_refresh_cache
+from ..manager.models import Measurement, post_refresh_cache
 from .models import WorkflowResult
 from .zip_model import ResultZipContainer
 
@@ -58,8 +58,8 @@ def post_delete_analysis(sender, instance, **kwargs):
         instance.permissions.delete()
     except get_permission_model().DoesNotExist:
         # This permissions set may have been deleted when analysis was deleted in
-        # pre_delete_topography. This happens when a surface is deleted, which
-        # trigger pre_delete_topography and this triggers pre_delete_analysis twice
+        # pre_delete_measurement. This happens when a surface is deleted, which
+        # trigger pre_delete_measurement and this triggers pre_delete_analysis twice
         pass
 
 
@@ -85,12 +85,12 @@ def _related_analysis_pks(instance):
     Covers the topography's own analysis plus every analysis attached to its
     surface via the legacy FK or the surface-set M2M. Only valid for a saved
     instance (``instance.pk`` set); for a not-yet-saved measurement use
-    ``_surface_scoped_analysis_pks`` so ``subject_topography=instance`` does
+    ``_surface_scoped_analysis_pks`` so ``subject_measurement=instance`` does
     not degenerate into an ``IS NULL`` match on unrelated analyses.
     """
     return list(
         WorkflowResult.objects.filter(
-            Q(subject_topography=instance)
+            Q(subject_measurement=instance)
             | Q(subject_surface=instance.surface)
             | Q(surfaces=instance.surface)
         )
@@ -99,7 +99,7 @@ def _related_analysis_pks(instance):
     )
 
 
-@receiver(post_refresh_cache, sender=Topography)
+@receiver(post_refresh_cache, sender=Measurement)
 def delete_all_related_analyses(sender, instance, **kwargs):
     # Cache is renewed, this means something significant changed and we need to remove
     # the analyses
@@ -113,7 +113,7 @@ def delete_all_related_analyses(sender, instance, **kwargs):
     WorkflowResult.objects.filter(pk__in=pks).update(deprecation_time=timezone.now())
 
 
-@receiver(pre_save, sender=Topography)
+@receiver(pre_save, sender=Measurement)
 def pre_measurement_save(sender, instance, **kwargs):
     created = instance.pk is None
     if created:
@@ -132,8 +132,8 @@ def pre_measurement_save(sender, instance, **kwargs):
         analyses.delete()
 
 
-@receiver(pre_delete, sender=Topography)
-def pre_delete_topography(sender, instance, **kwargs):
+@receiver(pre_delete, sender=Measurement)
+def pre_delete_measurement(sender, instance, **kwargs):
     # The topography analysis is automatically deleted, but we have to delete the
     # corresponding surface analysis; we do this after the transaction has finished
     # so we can check whether the surface still exists.

--- a/topobank/analysis/sizing.py
+++ b/topobank/analysis/sizing.py
@@ -131,10 +131,10 @@ def observed_bytes_per_point(use_cache=True):
             task_memory__isnull=False,
             task_memory__gt=0,
             task_end_time__gte=timezone.now() - timedelta(days=window_days),
-            subject_topography__isnull=False,
-            subject_topography__resolution_x__isnull=False,
+            subject_measurement__isnull=False,
+            subject_measurement__resolution_x__isnull=False,
         )
-        .annotate(points=_points_expression("subject_topography__"))
+        .annotate(points=_points_expression("subject_measurement__"))
         .values_list("workflow_name", "task_memory", "points")
     )
 
@@ -168,23 +168,23 @@ def grid_points(analysis):
     walking the tag tree across both surfaces and measurements, and a guard that
     is wrong is worse than a guard that abstains.
     """
-    from topobank.manager.models import Topography
+    from topobank.manager.models import Measurement
 
-    if analysis.subject_topography_id is not None:
-        topography = analysis.subject_topography
+    if analysis.subject_measurement_id is not None:
+        topography = analysis.subject_measurement
         if topography.resolution_x is None:
             return None
         return topography.resolution_x * (topography.resolution_y or 1)
 
     if analysis.subject_surface_id is not None:
-        queryset = Topography.objects.filter(surface_id=analysis.subject_surface_id)
+        queryset = Measurement.objects.filter(surface_id=analysis.subject_surface_id)
     elif analysis.subject_tag_id is not None:
         return None
     else:
         surface_ids = list(analysis.surfaces.values_list("id", flat=True))
         if not surface_ids:
             return None
-        queryset = Topography.objects.filter(surface_id__in=surface_ids)
+        queryset = Measurement.objects.filter(surface_id__in=surface_ids)
 
     return (
         queryset.filter(resolution_x__isnull=False)

--- a/topobank/analysis/tasks.py
+++ b/topobank/analysis/tasks.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from muTimer import Timer
 from SurfaceTopography.Support import doi
 
-from ..manager.models import Surface, Tag, Topography
+from ..manager.models import Surface, Tag, Measurement
 from ..supplib.db import advisory_lock
 from ..supplib.dict import store_split_dict
 from ..taskapp.celeryapp import app
@@ -130,7 +130,7 @@ def schedule_workflow(
     # Optimize query with select_related to reduce DB round trips
     analysis = (
         WorkflowResult.objects.select_related(
-            "subject_topography",
+            "subject_measurement",
             "subject_surface",
             "subject_tag",
             "configuration",
@@ -332,7 +332,7 @@ def execute_workflow(
     #
     analysis = (
         WorkflowResult.objects.select_related(
-            "subject_topography",
+            "subject_measurement",
             "subject_surface",
             "subject_tag",
             "configuration",
@@ -587,7 +587,7 @@ def current_statistics(user=None):
         dict with keys
 
         - num_surfaces_excluding_publications
-        - num_topographies_excluding_publications
+        - num_measurements_excluding_publications
         - num_analyses_excluding_publications
     """
     from .models import WorkflowResult
@@ -604,16 +604,16 @@ def current_statistics(user=None):
             unpublished_surfaces = Surface.objects.filter(created_by=user)
         else:
             unpublished_surfaces = Surface.objects.all()
-    unpublished_topographies = Topography.objects.filter(
+    unpublished_topographies = Measurement.objects.filter(
         surface__in=unpublished_surfaces
     )
     unpublished_analyses = WorkflowResult.objects.filter(
-        subject_topography__in=unpublished_topographies
+        subject_measurement__in=unpublished_topographies
     )
 
     return dict(
         num_surfaces_excluding_publications=unpublished_surfaces.count(),
-        num_topographies_excluding_publications=unpublished_topographies.count(),
+        num_measurements_excluding_publications=unpublished_topographies.count(),
         num_analyses_excluding_publications=unpublished_analyses.count(),
     )
 
@@ -644,7 +644,7 @@ def prepare_dependency_tasks(
             subject_hash = WorkflowResult.compute_subject_hash("surfaces", [subject.id])
         elif isinstance(subject, Surface):
             subject_hash = WorkflowResult.compute_subject_hash("surface", [subject.id])
-        elif isinstance(subject, Topography):
+        elif isinstance(subject, Measurement):
             subject_hash = WorkflowResult.compute_subject_hash(
                 "topography", [subject.id]
             )
@@ -657,7 +657,7 @@ def prepare_dependency_tasks(
             workflow_name=dependency.function.name,
             subject_hash=subject_hash,
             kwargs=kwargs,
-        ).select_related("subject_topography", "subject_surface", "subject_tag")
+        ).select_related("subject_measurement", "subject_surface", "subject_tag")
         if use_surfaces_path and isinstance(subject, Surface):
             existing_analysis_qs = existing_analysis_qs.prefetch_related("surfaces")
         # Serialize the existence check and creation of this dependency against
@@ -690,8 +690,8 @@ def prepare_dependency_tasks(
                     pass  # subject stored in M2M below; no FK field set
                 elif isinstance(subject, Surface):
                     create_kwargs["subject_surface"] = subject
-                elif isinstance(subject, Topography):
-                    create_kwargs["subject_topography"] = subject
+                elif isinstance(subject, Measurement):
+                    create_kwargs["subject_measurement"] = subject
                 elif isinstance(subject, Tag):
                     create_kwargs["subject_tag"] = subject
 

--- a/topobank/analysis/utils.py
+++ b/topobank/analysis/utils.py
@@ -36,10 +36,10 @@ def filter_and_order_analyses(analyses):
         OrderedDict()
     )  # always the same order of surfaces for same list of subjects
     for topography_analysis in sorted(
-        [a for a in analyses if a.subject_topography_id is not None],
-        key=lambda a: a.subject_topography_id,
+        [a for a in analyses if a.subject_measurement_id is not None],
+        key=lambda a: a.subject_measurement_id,
     ):
-        surface = topography_analysis.subject_topography.surface
+        surface = topography_analysis.subject_measurement.surface
         if surface not in analysis_groups:
             analysis_groups[surface] = []
         analysis_groups[surface].append(topography_analysis)
@@ -59,7 +59,7 @@ def filter_and_order_analyses(analyses):
             # Is there an analysis for the corresponding surface?
             surface_analysis_index = surfaces_of_surface_analyses.index(surface)
             surface_analysis = analyses_of_surfaces[surface_analysis_index]
-            if surface.num_topographies() > 1:
+            if surface.num_measurements() > 1:
                 # only show average for surface if more than one topography
                 sorted_analyses.append(surface_analysis)
                 surface_analysis_index = len(sorted_analyses) - 1  # last one
@@ -95,17 +95,17 @@ def filter_and_order_analyses(analyses):
 
 def find_children(subjects):
     """
-    Find all children for listed subjects. For example, a Topography is a child
+    Find all children for listed subjects. For example, a Measurement is a child
     of a Surface.
 
     Parameters
     ----------
-    subjects : list of Topography or Surface
+    subjects : list of Measurement or Surface
         List of subjects.
 
     Returns
     -------
-    List of Topography or Surface
+    List of Measurement or Surface
         List of subjects, updated with children.
     """
     if subjects is None:
@@ -114,7 +114,7 @@ def find_children(subjects):
     additional_subjects = []
     for subject in subjects:
         if isinstance(subject, Surface):
-            additional_subjects += list(subject.topography_set.all())
+            additional_subjects += list(subject.measurements.all())
     return list(set(subjects + additional_subjects))
 
 

--- a/topobank/authorization/models.py
+++ b/topobank/authorization/models.py
@@ -97,7 +97,7 @@ class AuthorizedManager(models.Manager):
 
 
 class SurfaceTopographyManager(AuthorizedManager):
-    """Default manager for Surface and Topography that excludes soft-deleted records."""
+    """Default manager for Surface and Measurement that excludes soft-deleted records."""
 
     def get_queryset(self) -> AuthorizedQuerySet:
         return super().get_queryset().filter(deletion_time__isnull=True)

--- a/topobank/manager/admin.py
+++ b/topobank/manager/admin.py
@@ -105,7 +105,7 @@ class SurfaceAdmin(TagFieldAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(Measurement)
-class TopographyAdmin(TagFieldAdminMixin, admin.ModelAdmin):
+class MeasurementAdmin(TagFieldAdminMixin, admin.ModelAdmin):
     list_display = ("id", "name", "deletion_time", "created_at", "task_state", "task_id")
     list_filter = ("task_state",)
     ordering = ["-created_at"]

--- a/topobank/manager/admin.py
+++ b/topobank/manager/admin.py
@@ -2,7 +2,7 @@ import tagulous.models.fields
 from django.contrib import admin
 from tagulous.admin import TagModelAdmin
 
-from .models import Surface, Tag, Topography
+from .models import Surface, Tag, Measurement
 
 # Monkey-patch FakeQuerySet to display properly in admin
 # This is needed for Django 5.2 compatibility with tagulous
@@ -104,7 +104,7 @@ class SurfaceAdmin(TagFieldAdminMixin, admin.ModelAdmin):
         return str(obj.tags) if obj.tags else ""
 
 
-@admin.register(Topography)
+@admin.register(Measurement)
 class TopographyAdmin(TagFieldAdminMixin, admin.ModelAdmin):
     list_display = ("id", "name", "deletion_time", "created_at", "task_state", "task_id")
     list_filter = ("task_state",)
@@ -129,7 +129,7 @@ class TopographyAdmin(TagFieldAdminMixin, admin.ModelAdmin):
     )
 
     def get_queryset(self, request):
-        return Topography.all_objects.all()
+        return Measurement.all_objects.all()
 
 
 @admin.register(Tag)

--- a/topobank/manager/custodian.py
+++ b/topobank/manager/custodian.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from topobank.files.models import Manifest
 
 from ..taskapp.celeryapp import app
-from .models import Surface, Topography
+from .models import Surface, Measurement
 from .zip_model import ZipContainer
 
 _log = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ def periodic_cleanup():
     )
 
     # Delete all topographies that were marked for deletion
-    q = Topography.all_objects.filter(
+    q = Measurement.all_objects.filter(
         deletion_time__lt=timezone.now() - settings.TOPOBANK_DELETE_DELAY
     )
     if q.count() > 0:

--- a/topobank/manager/export_zip.py
+++ b/topobank/manager/export_zip.py
@@ -18,7 +18,7 @@ import topobank
 from topobank.supplib.json import ExtendedJSONEncoder
 
 from .container_schema import CONTAINER_METADATA_FILENAME, ContainerMeta
-from .models import Topography
+from .models import Measurement
 
 _log = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def export_container_zip(file, surfaces, extra_metadata=None, progress_recorder=
     # One step per measurement, plus a final one for the metadata and license
     # files, so that a client can show a meaningful bar rather than an
     # indeterminate spinner.
-    nb_steps = 1 + Topography.objects.filter(surface__in=surfaces).count()
+    nb_steps = 1 + Measurement.objects.filter(surface__in=surfaces).count()
     step = 0
     if progress_recorder is not None:
         progress_recorder.set_progress(step, nb_steps, message="Preparing container")
@@ -75,7 +75,7 @@ def export_container_zip(file, surfaces, extra_metadata=None, progress_recorder=
             else f"{surface_index}".zfill(log10_nb_surfaces + 1) + "-"
         )
 
-        topographies = surface.topography_set.all()
+        topographies = surface.measurements.all()
 
         topography_dicts = []
 
@@ -179,7 +179,7 @@ def export_container_zip(file, surfaces, extra_metadata=None, progress_recorder=
     ============================
     This archive contains {len(surfaces)} digital surface twin(s). Each digital surface
     twin is a collection of individual topography measurements. In total,
-    this archive contains {sum(s.topography_set.count() for s in surfaces)} topography measurements.
+    this archive contains {sum(s.measurements.count() for s in surfaces)} topography measurements.
 
     There are two files for each measurement:
     - The original data file which was uploaded by a user,

--- a/topobank/manager/import_zip.py
+++ b/topobank/manager/import_zip.py
@@ -10,7 +10,7 @@ from .container_schema import (
     ContainerMeta,
     TopographyMeta,
 )
-from .models import Surface, Topography
+from .models import Surface, Measurement
 
 
 def load_container_metadata(surface_zip, unsafe_yaml_loader=False) -> ContainerMeta:
@@ -96,7 +96,7 @@ def import_measurement(topo_meta: TopographyMeta, topo_file, surface):
         # because of the file contents while loading.
         topo_kwargs["height_scale"] = topo_meta.height_scale
 
-    topography = Topography(**topo_kwargs)
+    topography = Measurement(**topo_kwargs)
     topography.datafile = Manifest.objects.create(
         permissions=surface.permissions, filename=topo_meta.name, created_by=user
     )

--- a/topobank/manager/management/commands/import_datasets.py
+++ b/topobank/manager/management/commands/import_datasets.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.timezone import now
 
 from topobank.manager.import_zip import load_container_metadata
-from topobank.manager.models import Surface, Topography
+from topobank.manager.models import Surface, Measurement
 from topobank.properties.models import Property
 
 User = _get_user_model()
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         )
 
     def process_topography(self, topo_meta, topo_file, surface, dry_run=False):
-        self.stdout.write(self.style.NOTICE(f"  Topography name: '{topo_meta.name}'"))
+        self.stdout.write(self.style.NOTICE(f"  Measurement name: '{topo_meta.name}'"))
         if topo_meta.created_by is not None:
             self.stdout.write(
                 self.style.NOTICE(
@@ -117,13 +117,13 @@ class Command(BaseCommand):
         # Constructing the instance validates the metadata. On a dry run we stop
         # here: nothing is persisted (the surface is not saved either, so saving
         # the topography would fail on the unsaved foreign key).
-        topography = Topography(**topo_kwargs)
+        topography = Measurement(**topo_kwargs)
 
         if not dry_run:
             # ...which we need for the storage prefix
             topography.save_datafile(topo_file)
             self.stdout.write(
-                self.style.SUCCESS(f"Topography '{topo_name}' saved in database.")
+                self.style.SUCCESS(f"Measurement '{topo_name}' saved in database.")
             )
             # Renew/generate cache
             topography.refresh_cache()
@@ -173,11 +173,11 @@ class Command(BaseCommand):
                     self.style.SUCCESS(f"Surface '{surface.name}' saved.")
                 )
 
-            num_topographies = len(surface_meta.topographies)
+            num_measurements = len(surface_meta.topographies)
             for topo_idx, topo_meta in enumerate(surface_meta.topographies):
                 self.stdout.write(
                     self.style.NOTICE(
-                        f"Processing topography {topo_idx + 1}/{num_topographies} in archive..."
+                        f"Processing topography {topo_idx + 1}/{num_measurements} in archive..."
                     )
                 )
                 datafile_name = topo_meta.datafile.original

--- a/topobank/manager/management/commands/refresh_cache.py
+++ b/topobank/manager/management/commands/refresh_cache.py
@@ -4,7 +4,7 @@ import traceback
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 from topobank.taskapp.utils import run_task
 
 _log = logging.getLogger(__name__)
@@ -40,9 +40,9 @@ class Command(BaseCommand):
         num_failed = 0
         num_success = 0
 
-        num_total = Topography.objects.count()
+        num_total = Measurement.objects.count()
 
-        for topo_idx, topo in enumerate(Topography.objects.order_by('name')):
+        for topo_idx, topo in enumerate(Measurement.objects.order_by('name')):
             _log.info(f"Renewing cache file for '{topo.name}', id {topo.id}, {topo_idx + 1}/{num_total}..")
 
             try:
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                     # operator sees 'pending' immediately (run_task only sets it
                     # in memory via autosave=False) and lets run_task's on_commit
                     # dispatch fire after the pending state is committed -- the
-                    # same pattern as Topography.ensure_task_started().
+                    # same pattern as Measurement.ensure_task_started().
                     with transaction.atomic():
                         run_task(topo, force=True)
                         topo.save()

--- a/topobank/manager/management/commands/set_datafile_format.py
+++ b/topobank/manager/management/commands/set_datafile_format.py
@@ -9,12 +9,12 @@ _log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = """Set datafile format for topographies which haven't one yet.
+    help = """Set datafile format for measurements which haven't one yet.
 
     If the datafile format is set, a file can be loaded more efficiently.
-    Normally this is set when uploading a new topography. For some
-    old topographies or in case the format specifiers change, it may
-    be needed to rerun format detection over all topographies saved in the
+    Normally this is set when uploading a new measurement. For some
+    old measurements or in case the format specifiers change, it may
+    be needed to rerun format detection over all measurements saved in the
     database. This can be done with this command.
     """
 
@@ -25,14 +25,14 @@ class Command(BaseCommand):
             '--all',
             action='store_true',
             dest='all',
-            help='Process all topographies, also those which already have a format.',
+            help='Process all measurements, also those which already have a format.',
         )
 
         parser.add_argument(
             '--dry-run',
             action='store_true',
             dest='dry_run',
-            help='Just traverse topographies but actually do not save format into database.',
+            help='Just traverse measurements but actually do not save format into database.',
         )
 
     def handle(self, *args, **options):
@@ -40,58 +40,58 @@ class Command(BaseCommand):
         format_counts = {None: 0}
         num_cannot_openend = 0  # number of files which cannot be openend
 
-        topographies = Measurement.objects.all()
+        measurements = Measurement.objects.all()
         if not options['all']:
-            topographies = topographies.filter(datafile_format__isnull=True)
-        num_measurements = topographies.count()
+            measurements = measurements.filter(datafile_format__isnull=True)
+        num_measurements = measurements.count()
 
-        for topo in topographies:
-            if topo.datafile_format is None:
+        for measurement in measurements:
+            if measurement.datafile_format is None:
                 try:
-                    datafile = topo.datafile
+                    datafile = measurement.datafile
                     # Workaround such that module "SurfaceTopography" recognizes this a binary stream
                     if not hasattr(datafile, 'mode'):
                         datafile.mode = 'rb'
                     datafile_format = detect_format(datafile)
                 except CannotDetectFileFormat as exc:
-                    msg = f"Could not detect format for topography id {topo.id}: " + str(exc)
+                    msg = f"Could not detect format for measurement id {measurement.id}: " + str(exc)
                     self.stdout.write(self.style.WARNING(msg))
                     format_counts[None] += 1
                     continue
                 except Exception as exc:
-                    msg = f"Could not open file for topography id {topo.id}: " + str(exc)
+                    msg = f"Could not open file for measurement id {measurement.id}: " + str(exc)
                     self.stdout.write(self.style.WARNING(msg))
                     num_cannot_openend += 1
                     continue
 
                 if not options['dry_run']:
-                    topo.datafile_format = datafile_format
-                    topo.save()
+                    measurement.datafile_format = datafile_format
+                    measurement.save()
 
                 if datafile_format not in format_counts:
                     format_counts[datafile_format] = 1
                 else:
                     format_counts[datafile_format] += 1
 
-        self.stdout.write(self.style.SUCCESS(f"Processed {num_measurements} specified topographies."))
+        self.stdout.write(self.style.SUCCESS(f"Processed {num_measurements} specified measurements."))
 
         if num_cannot_openend == 0:
-            self.stdout.write(self.style.SUCCESS("All specified topography files can be opened."))
+            self.stdout.write(self.style.SUCCESS("All specified measurement files can be opened."))
         else:
-            self.stdout.write(self.style.ERROR("In total {} of {} topographies currently cannot be opened.".format(
+            self.stdout.write(self.style.ERROR("In total {} of {} measurements currently cannot be opened.".format(
                 num_cannot_openend, num_measurements)))
 
-        self.stdout.write(self.style.SUCCESS("Frequencies of topographies which could be opened:"))
+        self.stdout.write(self.style.SUCCESS("Frequencies of measurements which could be opened:"))
         for fmt, freq in format_counts.items():
             self.stdout.write(self.style.SUCCESS(f"  {fmt}: {freq}"))
 
         if format_counts[None] == 0:
             self.stdout.write(
-                self.style.SUCCESS("All {} topography files which can be opened can also be loaded.".format(
+                self.style.SUCCESS("All {} measurement files which can be opened can also be loaded.".format(
                     num_measurements - num_cannot_openend)))
         else:
             self.stdout.write(
-                self.style.WARNING("In total {} topographies currently can be opened, but not be loaded.".format(
+                self.style.WARNING("In total {} measurements currently can be opened, but not be loaded.".format(
                     format_counts[None])))
 
         if options['dry_run']:

--- a/topobank/manager/management/commands/set_datafile_format.py
+++ b/topobank/manager/management/commands/set_datafile_format.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 from SurfaceTopography.IO import CannotDetectFileFormat, detect_format
 
-from topobank.manager.models import Topography
+from topobank.manager.models import Measurement
 
 _log = logging.getLogger(__name__)
 
@@ -40,10 +40,10 @@ class Command(BaseCommand):
         format_counts = {None: 0}
         num_cannot_openend = 0  # number of files which cannot be openend
 
-        topographies = Topography.objects.all()
+        topographies = Measurement.objects.all()
         if not options['all']:
             topographies = topographies.filter(datafile_format__isnull=True)
-        num_topographies = topographies.count()
+        num_measurements = topographies.count()
 
         for topo in topographies:
             if topo.datafile_format is None:
@@ -73,13 +73,13 @@ class Command(BaseCommand):
                 else:
                     format_counts[datafile_format] += 1
 
-        self.stdout.write(self.style.SUCCESS(f"Processed {num_topographies} specified topographies."))
+        self.stdout.write(self.style.SUCCESS(f"Processed {num_measurements} specified topographies."))
 
         if num_cannot_openend == 0:
             self.stdout.write(self.style.SUCCESS("All specified topography files can be opened."))
         else:
             self.stdout.write(self.style.ERROR("In total {} of {} topographies currently cannot be opened.".format(
-                num_cannot_openend, num_topographies)))
+                num_cannot_openend, num_measurements)))
 
         self.stdout.write(self.style.SUCCESS("Frequencies of topographies which could be opened:"))
         for fmt, freq in format_counts.items():
@@ -88,7 +88,7 @@ class Command(BaseCommand):
         if format_counts[None] == 0:
             self.stdout.write(
                 self.style.SUCCESS("All {} topography files which can be opened can also be loaded.".format(
-                    num_topographies - num_cannot_openend)))
+                    num_measurements - num_cannot_openend)))
         else:
             self.stdout.write(
                 self.style.WARNING("In total {} topographies currently can be opened, but not be loaded.".format(

--- a/topobank/manager/migrations/0084_rename_topography_measurement.py
+++ b/topobank/manager/migrations/0084_rename_topography_measurement.py
@@ -1,0 +1,78 @@
+"""
+Rename `Topography` to `Measurement`.
+
+The model is the generic record of a measurement -- identity, permissions, files
+and task state -- rather than something specific to topography data. Presently
+every measurement still holds height data; this only renames it.
+
+Besides the model itself this renames the reverse accessor on `Surface`
+(``topography_set`` becomes ``measurements``). It also rewrites the model's row in
+`django_content_type`: Django's `RenameModel` does not touch that table, and
+anything referring to a measurement through a generic foreign key - notifications,
+most importantly - resolves through it.
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def rename_content_type(apps, schema_editor):
+    """
+    Point the existing content type at the new model name.
+
+    Updating the row in place (rather than letting `get_for_model` create a new
+    one) keeps its primary key, and with it every generic foreign key that
+    already refers to a measurement.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    ContentType.objects.filter(app_label="manager", model="topography").update(
+        model="measurement"
+    )
+    # The content-type cache may already hold the old name in a long-running
+    # process (e.g. when migrations run inside a web worker).
+    ContentType.objects.clear_cache()
+
+
+def restore_content_type(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    ContentType.objects.filter(app_label="manager", model="measurement").update(
+        model="topography"
+    )
+    ContentType.objects.clear_cache()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        # Older `analysis` migrations refer to `manager.topography` by name, so
+        # they all have to have run before the model is renamed out from under
+        # them.
+        ("analysis", "0064_backfill_subject_hash"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("manager", "0083_topography_undefined_data_fraction"),
+    ]
+
+    operations = [
+        migrations.RenameModel(old_name="Topography", new_name="Measurement"),
+        # `surface.topography_set` becomes `surface.measurements`. `related_name`
+        # lives only in Django's model state, so this is a state operation with no
+        # database counterpart. The reverse accessors of the file manifests
+        # (`manifest.topography_datafiles` and friends) are deliberately left
+        # alone: renaming them would pull the `files` app forward in the migration
+        # graph, and nothing about the model rename requires it.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="measurement",
+                    name="surface",
+                    field=models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="measurements",
+                        to="manager.surface",
+                    ),
+                ),
+            ],
+        ),
+        migrations.RunPython(rename_content_type, restore_content_type),
+    ]

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -1144,7 +1144,7 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         apply_filters: bool = True,
         return_reader: bool = False,
     ):
-        """Return a SurfaceTopography.Measurement/UniformLineScan/NonuniformLineScan instance.
+        """Return a SurfaceTopography.Topography/UniformLineScan/NonuniformLineScan instance.
 
         This instance is guaranteed to
 

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -97,7 +97,7 @@ class TopobankLazySurfaceContainer(SurfaceContainer):
 
     def __init__(self, surface, **kwargs):
         self._surface = surface
-        self._topographies = self._surface.topography_set.all()
+        self._topographies = self._surface.measurements.all()
         self._kwargs = kwargs
 
     def __len__(self):
@@ -445,8 +445,8 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
     def get_related_surfaces(self):
         return [self]
 
-    def num_topographies(self):
-        return self.topography_set.count()
+    def num_measurements(self):
+        return self.measurements.count()
 
     def save(self, *args, **kwargs):
         created = self.pk is None
@@ -473,7 +473,7 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
     def lazy_delete(self):
         self.deletion_time = timezone.now()
         self.save(update_fields=["deletion_time"])
-        self.topography_set.filter(deletion_time__isnull=True).update(
+        self.measurements.filter(deletion_time__isnull=True).update(
             deletion_time=self.deletion_time
         )
 
@@ -490,7 +490,7 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
             self.created_by.name if self.created_by is not None else "",
         ]
         parts += [flatten_for_search(tag.name) for tag in self.tags.all()]
-        for topography in self.topography_set.select_related("created_by").prefetch_related("tags").all():
+        for topography in self.measurements.select_related("created_by").prefetch_related("tags").all():
             parts += [
                 flatten_for_search(topography.name),
                 topography.description or "",
@@ -525,7 +525,7 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
         Does not include topographies. They can be added like this:
 
          surface_dict = surface.to_dict()
-         surface_dict['topographies'] = [t.to_dict() for t in surface.topography_set.order_by('name')]
+         surface_dict['topographies'] = [t.to_dict() for t in surface.measurements.order_by('name')]
 
         The publication URL will be based on the official contact.engineering URL.
 
@@ -612,7 +612,7 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
         surface.attachments = self.attachments.deepcopy(permissions=surface.permissions)
         surface.save(update_fields=["attachments"])
 
-        for topography in self.topography_set.all():
+        for topography in self.measurements.all():
             topography.deepcopy(surface)
             # we pass the surface here because there is a constraint that (surface_id +
             # topography name) must be unique, i.e. a surface should never have two
@@ -640,9 +640,13 @@ class Surface(PermissionMixin, models.Model, SubjectMixin):
         return TopobankLazySurfaceContainer(self, **kwargs)
 
 
-class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
+class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
     """
-    A single topography measurement of a surface of a specimen.
+    A single measurement of a surface of a specimen.
+
+    Presently every measurement holds topography (height) data; the name is
+    deliberately generic because the model itself carries only identity,
+    permissions, files and task state.
     """
 
     celery_queue = settings.TOPOBANK_MANAGER_QUEUE
@@ -706,7 +710,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         verbose_name_plural = "measurements"
         indexes = [
             # Index on surface foreign key for JOIN optimization
-            # Used in: surface.topography_set.all() and filtering by surface__deletion_time
+            # Used in: surface.measurements.all() and filtering by surface__deletion_time
             models.Index(fields=['surface'], name='topography_surface_idx'),
             # Composite index for filtering and ordering
             # Used in: list queries with deletion_time filter
@@ -740,7 +744,9 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         getattr(settings, 'TOPOBANK_PERMISSION_MODEL', 'authorization.PermissionSet'),
         on_delete=models.CASCADE, null=True
     )
-    surface = models.ForeignKey(Surface, on_delete=models.CASCADE)
+    surface = models.ForeignKey(
+        Surface, on_delete=models.CASCADE, related_name="measurements"
+    )
 
     #
     # Descriptive fields
@@ -930,7 +936,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
                 update_fields.append('attachments')
         if self.datafile is None:
             _log.debug(
-                f"DATAFILE MISSING: Creating datafile manifest for Topography: {self}")
+                f"DATAFILE MISSING: Creating datafile manifest for Measurement: {self}")
             self.datafile = Manifest.objects.create(
                 permissions=self.permissions,
                 filename=self.name,
@@ -947,7 +953,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         # https://stackoverflow.com/questions/1355150/when-saving-how-can-you-check-if-a-field-has-changed
         try:
             # Do not check for None in self.id as this breaks should we switch to UUIDs
-            old_obj = Topography.objects.get(pk=self.pk)
+            old_obj = Measurement.objects.get(pk=self.pk)
         except self.DoesNotExist:
             pass  # Do nothing, we have just created a new topography
         else:
@@ -1048,7 +1054,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         """
         if self.id is None:
             raise RuntimeError(
-                "This `Topography` does not have an id yet; the storage prefix is not yet known."
+                "This `Measurement` does not have an id yet; the storage prefix is not yet known."
             )
         return f"topographies/{self.id}"
 
@@ -1089,7 +1095,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
             _log.warning(
                 "You are requesting to load a (2D) topography and you are not within in a Celery worker "
                 "process. This operation is potentially slow and may require a lot of memory - do not use "
-                "`Topography.read` within the main Django server!"
+                "`Measurement.read` within the main Django server!"
             )
 
         reader_kwargs = dict(channel_index=self.data_source, periodic=self.is_periodic)
@@ -1125,7 +1131,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         if apply_filters:
             if (
                 self.fill_undefined_data_mode
-                != Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING
+                != Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING
                 and topo.is_uniform
             ):
                 topo = topo.interpolate_undefined_data(self.fill_undefined_data_mode)
@@ -1138,7 +1144,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         apply_filters: bool = True,
         return_reader: bool = False,
     ):
-        """Return a SurfaceTopography.Topography/UniformLineScan/NonuniformLineScan instance.
+        """Return a SurfaceTopography.Measurement/UniformLineScan/NonuniformLineScan instance.
 
         This instance is guaranteed to
 
@@ -1182,7 +1188,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
                 _log.warning(
                     "You are requesting to load a (2D) topography and you are not within in a Celery worker "
                     "process. This operation is potentially slow and may require a lot of memory - do not use "
-                    "`Topography.read` within the main Django server!"
+                    "`Measurement.read` within the main Django server!"
                 )
 
             # Okay, we can use the squeezed datafile, it's already there.
@@ -1207,7 +1213,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
                 topo = self._read(toporeader, apply_filters=apply_filters)
             else:
                 raise RuntimeError(
-                    f"Topography {self.id} does not appear to have a data file."
+                    f"Measurement {self.id} does not appear to have a data file."
                 )
 
         if return_reader:
@@ -1270,7 +1276,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
         The reference to an instrument is not copied, it is always None.
 
         """
-        copy = Topography.objects.get(pk=self.pk)
+        copy = Measurement.objects.get(pk=self.pk)
         copy.pk = None  # This will lead to the creation of a new instance on save
         copy.task_id = None  # We need to indicate that no tasks have run
         copy.surface = to_surface
@@ -1563,13 +1569,13 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
 
         # Send signal
         _log.debug(f"Sending `pre_refresh_cache` signal from {self}...")
-        pre_refresh_cache.send(sender=Topography, instance=self)
+        pre_refresh_cache.send(sender=Measurement, instance=self)
 
         with timer("exists"):
             # First check if we have a datafile
             if not self.datafile.exists():
                 raise RuntimeError(
-                    f"Topography {self.id} does not appear to have a data file. Cannot "
+                    f"Measurement {self.id} does not appear to have a data file. Cannot "
                     f"refresh cached data."
                 )
 
@@ -1809,7 +1815,7 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
 
         # Send signal
         _log.debug(f"Sending `post_refresh_cache` signal from {self}...")
-        post_refresh_cache.send(sender=Topography, instance=self)
+        post_refresh_cache.send(sender=Measurement, instance=self)
 
     def get_undefined_data_status(self):
         """Get human-readable description about status of undefined data as string."""
@@ -1819,12 +1825,12 @@ class Topography(PermissionMixin, TaskStateModel, SubjectMixin):
             s += f" {percentage}% of the data points are undefined."
         if (
             self.fill_undefined_data_mode
-            == Topography.FILL_UNDEFINED_DATA_MODE_NOFILLING
+            == Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING
         ):
             s += " No correction of undefined data is performed."
         elif (
             self.fill_undefined_data_mode
-            == Topography.FILL_UNDEFINED_DATA_MODE_HARMONIC
+            == Measurement.FILL_UNDEFINED_DATA_MODE_HARMONIC
         ):
             s += (
                 " Undefined/missing values are filled in with values obtained from a "

--- a/topobank/manager/signals.py
+++ b/topobank/manager/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 from notifications.models import Notification
 
 from ..authorization import get_permission_model
-from .models import Surface, Topography
+from .models import Surface, Measurement
 from .zip_model import ZipContainer
 
 _log = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ _log = logging.getLogger(__name__)
 # Fields that contribute to the full-text search document. Saves that only
 # touch other fields (e.g. task state updates) do not trigger a re-index.
 _SURFACE_SEARCH_FIELDS = {"name", "description", "created_by"}
-_TOPOGRAPHY_SEARCH_FIELDS = {"name", "description", "created_by"}
+_MEASUREMENT_SEARCH_FIELDS = {"name", "description", "created_by"}
 
 
 def _remove_notifications(instance):
@@ -24,8 +24,8 @@ def _remove_notifications(instance):
     ).delete()
 
 
-@receiver(pre_delete, sender=Topography)
-def pre_delete_topography(sender, instance, using, **kwargs):
+@receiver(pre_delete, sender=Measurement)
+def pre_delete_measurement(sender, instance, using, **kwargs):
     _remove_notifications(instance)
     instance.remove_files()
 
@@ -56,18 +56,18 @@ def update_surface_search_vector(sender, instance, created, update_fields, **kwa
         instance.update_search_vector()
 
 
-@receiver(post_save, sender=Topography)
-def update_search_vector_on_topography_save(
+@receiver(post_save, sender=Measurement)
+def update_search_vector_on_measurement_save(
     sender, instance, created, update_fields, **kwargs
 ):
     if created or _searchable_fields_changed(
-        update_fields, _TOPOGRAPHY_SEARCH_FIELDS
+        update_fields, _MEASUREMENT_SEARCH_FIELDS
     ):
         _update_parent_search_vector(instance)
 
 
-@receiver(post_delete, sender=Topography)
-def update_search_vector_on_topography_delete(sender, instance, using, **kwargs):
+@receiver(post_delete, sender=Measurement)
+def update_search_vector_on_measurement_delete(sender, instance, using, **kwargs):
     _update_parent_search_vector(instance)
 
 
@@ -89,8 +89,8 @@ def update_search_vector_on_surface_tags_change(
         instance.update_search_vector()
 
 
-@receiver(m2m_changed, sender=Topography.tags.through)
-def update_search_vector_on_topography_tags_change(
+@receiver(m2m_changed, sender=Measurement.tags.through)
+def update_search_vector_on_measurement_tags_change(
     sender, instance, action, reverse, **kwargs
 ):
     if action in ("post_add", "post_remove", "post_clear") and not reverse:

--- a/topobank/manager/utils.py
+++ b/topobank/manager/utils.py
@@ -24,7 +24,7 @@ from SurfaceTopography.Support.UnitConversion import (
 
 _log = logging.getLogger(__name__)
 
-# Length units offered in the UI (mirrors Topography.LENGTH_UNIT_CHOICES). The
+# Length units offered in the UI (mirrors Measurement.LENGTH_UNIT_CHOICES). The
 # natural-unit suggestion is clamped to this set so we never propose a unit the
 # frontend cannot display/select.
 _NATURAL_LENGTH_UNITS = {"km", "m", "mm", "µm", "nm", "Å", "pm"}
@@ -117,7 +117,7 @@ def detrend_parameters(st_topo):
     Parameters
     ----------
     st_topo : SurfaceTopography.HeightContainer.AbstractHeightContainer
-        Topography, as returned by `detrend`.
+        Measurement, as returned by `detrend`.
 
     Returns
     -------
@@ -175,7 +175,7 @@ def undefined_data_fraction(st_topo):
     Parameters
     ----------
     st_topo : SurfaceTopography.HeightContainer.AbstractHeightContainer
-        Topography, possibly the result of a chain of filters.
+        Measurement, possibly the result of a chain of filters.
 
     Returns
     -------
@@ -268,7 +268,7 @@ def subjects_to_dict(subjects):
 
     Parameters
     ----------
-    subjects : list of Topography or Surface or Tag
+    subjects : list of Measurement or Surface or Tag
         Subjects for serialization
 
     Returns
@@ -317,7 +317,7 @@ def subjects_from_dict(subjects_dict, user=None, function=None):
 
     Returns
     -------
-    List of subject instances (e.g. Topography or Surface)
+    List of subject instances (e.g. Measurement or Surface)
     """
 
     # Build list with potential subjects
@@ -388,7 +388,7 @@ def subjects_to_base64(subjects):
 
     Returns
     -------
-    List of subject instances (e.g. Topography or Surface)
+    List of subject instances (e.g. Measurement or Surface)
     """
     return dict_to_base64(subjects_to_dict(subjects))
 
@@ -400,7 +400,7 @@ def subjects_from_base64(subjects, user=None, function=None):
 
     Parameters
     ----------
-    subjects : list of Topography or Surface or Tag
+    subjects : list of Measurement or Surface or Tag
         Subjects for serialization
 
     Returns
@@ -501,7 +501,7 @@ def render_deepzoom(
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         try:
-            # This is a Topography
+            # This is a Measurement
             filenames = data.to_dzi(
                 "dzi",
                 root_directory=tmpdirname,
@@ -538,7 +538,7 @@ def render_deepzoom(
         # Generate NetCDF tiles for interactive viewer
         if generate_netcdf:
             try:
-                # This is a Topography
+                # This is a Measurement
                 nc_filenames = data.to_dzi(
                     "dzi-nc",
                     root_directory=tmpdirname,

--- a/topobank/taskapp/celeryapp.py
+++ b/topobank/taskapp/celeryapp.py
@@ -229,7 +229,7 @@ class CeleryAppConfig(AppConfig):
 
         Searches all models that inherit from TaskStateModel:
         - WorkflowResult (analysis results)
-        - Topography (dataset measurements)
+        - Measurement (dataset measurements)
         - ZipContainer (ZIP file exports)
 
         Returns None if not found.
@@ -239,11 +239,11 @@ class CeleryAppConfig(AppConfig):
 
         # Import here to avoid circular imports
         from topobank.analysis.models import WorkflowResult
-        from topobank.manager.models import Topography
+        from topobank.manager.models import Measurement
         from topobank.manager.zip_model import ZipContainer
 
         # Search each model type
-        for model_class in [WorkflowResult, Topography, ZipContainer]:
+        for model_class in [WorkflowResult, Measurement, ZipContainer]:
             try:
                 return model_class.objects.get(task_id=task_id)
             except model_class.DoesNotExist:

--- a/topobank/testing/factories.py
+++ b/topobank/testing/factories.py
@@ -374,7 +374,7 @@ class AnalysisFactory(AnalysisFactoryWithoutResult):
 
 
 class MeasurementAnalysisFactory(AnalysisFactory):
-    """Create an analysis for a topography."""
+    """Create an analysis for a measurement."""
 
     # noinspection PyMissingOrEmptyDocstring
     class Meta:
@@ -384,7 +384,7 @@ class MeasurementAnalysisFactory(AnalysisFactory):
 
 
 class FailedMeasurementAnalysisFactory(AnalysisFactory):
-    """Create an analysis for a topography."""
+    """Create an analysis for a measurement."""
 
     # noinspection PyMissingOrEmptyDocstring
     class Meta:

--- a/topobank/testing/factories.py
+++ b/topobank/testing/factories.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from factory import post_generation
 
 from ..analysis.models import Workflow, WorkflowResult
-from ..manager.models import Surface, Tag, Topography
+from ..manager.models import Surface, Tag, Measurement
 from ..properties.models import Property
 from .data import FIXTURE_DATA_DIR
 
@@ -193,12 +193,12 @@ class PropertyFactory(factory.django.DjangoModelFactory):
 
 class Topography1DFactory(factory.django.DjangoModelFactory):
     """
-    Generates a 1D Topography.
+    Generates a 1D Measurement.
     """
 
     # noinspection PyMissingOrEmptyDocstring
     class Meta:
-        model = Topography
+        model = Measurement
         exclude = ("filename",)
         skip_postgeneration_save = True
 
@@ -222,15 +222,15 @@ class Topography1DFactory(factory.django.DjangoModelFactory):
     height_scale_editable = True
     unit = "nm"
     instrument_name = ""
-    instrument_type = Topography.INSTRUMENT_TYPE_UNDEFINED
+    instrument_type = Measurement.INSTRUMENT_TYPE_UNDEFINED
     instrument_parameters = {}
     # `post_generation` below calls refresh_cache(), which is the body of the
-    # inspection task (see Topography.task_worker). Calling it directly bypasses
+    # inspection task (see Measurement.task_worker). Calling it directly bypasses
     # the task wrapper that would normally record the outcome, so factory-built
     # measurements would otherwise look like they were never inspected
     # successfully despite having a populated cache. Override to build a
-    # measurement in a different state, e.g. task_state=Topography.FAILURE.
-    task_state = Topography.SUCCESS
+    # measurement in a different state, e.g. task_state=Measurement.FAILURE.
+    task_state = Measurement.SUCCESS
 
     @factory.post_generation
     def post_generation(self, create, value, **kwargs):
@@ -245,16 +245,16 @@ class Topography1DFactory(factory.django.DjangoModelFactory):
         # after post_generation (`skip_postgeneration_save`), so writing it
         # both in memory and in the database keeps them consistent.
         self.task_state = requested_task_state
-        Topography.objects.filter(pk=self.pk).update(task_state=requested_task_state)
+        Measurement.objects.filter(pk=self.pk).update(task_state=requested_task_state)
 
 
 class Topography2DFactory(Topography1DFactory):
     """
-    Generates a 2D Topography.
+    Generates a 2D Measurement.
     """
 
     class Meta:
-        model = Topography
+        model = Measurement
         exclude = ("filename",)
 
     size_y = 512
@@ -304,7 +304,7 @@ class AnalysisFactoryWithoutResult(factory.django.DjangoModelFactory):
         )
         skip_postgeneration_save = True
 
-    subject_topography = None  # factory.SubFactory(Topography2DFactory)
+    subject_measurement = None  # factory.SubFactory(Topography2DFactory)
     subject_surface = None
     subject_tag = None
 
@@ -313,7 +313,7 @@ class AnalysisFactoryWithoutResult(factory.django.DjangoModelFactory):
         lambda obj: (
             obj.subject_surface
             if obj.subject_surface
-            else (obj.subject_topography if obj.subject_topography else obj.subject_tag)
+            else (obj.subject_measurement if obj.subject_measurement else obj.subject_tag)
         )
     )
 
@@ -322,8 +322,8 @@ class AnalysisFactoryWithoutResult(factory.django.DjangoModelFactory):
             obj.subject_surface.created_by
             if obj.subject_surface
             else (
-                obj.subject_topography.created_by
-                if obj.subject_topography
+                obj.subject_measurement.created_by
+                if obj.subject_measurement
                 else obj.subject_tag.get_related_surfaces().first().created_by
             )
         )
@@ -373,24 +373,24 @@ class AnalysisFactory(AnalysisFactoryWithoutResult):
     result = factory.LazyAttribute(_analysis_result)
 
 
-class TopographyAnalysisFactory(AnalysisFactory):
+class MeasurementAnalysisFactory(AnalysisFactory):
     """Create an analysis for a topography."""
 
     # noinspection PyMissingOrEmptyDocstring
     class Meta:
         model = WorkflowResult
 
-    subject_topography = factory.SubFactory(Topography2DFactory)
+    subject_measurement = factory.SubFactory(Topography2DFactory)
 
 
-class FailedTopographyAnalysisFactory(AnalysisFactory):
+class FailedMeasurementAnalysisFactory(AnalysisFactory):
     """Create an analysis for a topography."""
 
     # noinspection PyMissingOrEmptyDocstring
     class Meta:
         model = WorkflowResult
 
-    subject_topography = factory.SubFactory(Topography2DFactory)
+    subject_measurement = factory.SubFactory(Topography2DFactory)
     result = factory.LazyAttribute(_failed_analysis_result)
 
 

--- a/topobank/testing/fixtures.py
+++ b/topobank/testing/fixtures.py
@@ -339,7 +339,7 @@ def simple_surface():
             self._c = c
 
         @property
-        def topography_set(self):
+        def measurements(self):
             return WrapRequest(self._c)
 
     nx, ny = 113, 123

--- a/topobank/testing/utils.py
+++ b/topobank/testing/utils.py
@@ -16,7 +16,7 @@ from django.test import SimpleTestCase
 from django.utils import formats
 
 from topobank.files.models import ManifestSet
-from topobank.manager.models import Surface, Tag, Topography
+from topobank.manager.models import Surface, Tag, Measurement
 
 _log = logging.getLogger(__name__)
 
@@ -214,9 +214,9 @@ def assert_dicts_equal(a, b, key=None, ignore_keys=set(), rtol=1e-07, atol=0):
 
 @dataclass(frozen=True)
 class FakeTopographyModel:
-    """This model is used to create a Topography for  being passed to analysis functions."""
+    """This model is used to create a Measurement for  being passed to analysis functions."""
 
-    t: Topography
+    t: Measurement
     name: str = "mytopo"
     is_periodic: bool = False
 
@@ -226,10 +226,10 @@ class FakeTopographyModel:
 
 
 class AnalysisResultMock:
-    subject: Union[Tag, Surface, Topography] = None
+    subject: Union[Tag, Surface, Measurement] = None
     folder: ManifestSet = None
 
-    def __init__(self, subject: Union[Tag, Surface, Topography], folder: ManifestSet = None):
+    def __init__(self, subject: Union[Tag, Surface, Measurement], folder: ManifestSet = None):
         self.subject = subject
         self.folder = folder
         if self.folder is None and hasattr(self.subject, "permissions"):

--- a/topobank/testing/utils.py
+++ b/topobank/testing/utils.py
@@ -214,7 +214,7 @@ def assert_dicts_equal(a, b, key=None, ignore_keys=set(), rtol=1e-07, atol=0):
 
 @dataclass(frozen=True)
 class FakeTopographyModel:
-    """This model is used to create a Measurement for  being passed to analysis functions."""
+    """This model is used to create a Measurement for being passed to analysis functions."""
 
     t: Measurement
     name: str = "mytopo"

--- a/topobank/testing/workflows.py
+++ b/topobank/testing/workflows.py
@@ -10,7 +10,7 @@ from ..analysis.models import RESULT_FILE_BASENAME, Workflow
 from ..analysis.outputs import OutputFile
 from ..analysis.registry import register_implementation
 from ..analysis.workflows import WorkflowDefinition, WorkflowImplementation
-from ..manager.models import Surface, Tag, Topography
+from ..manager.models import Surface, Tag, Measurement
 from ..supplib.dict import store_split_dict
 from ..supplib.json import ExtendedJSONEncoder
 
@@ -27,7 +27,7 @@ class TestImplementation(WorkflowImplementation):
         display_name = "Test implementation"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
             Surface: "surface_implementation",
             Tag: "tag_implementation",
         }
@@ -144,10 +144,10 @@ class TopographyOnlyTestImplementation(TestImplementation):
 
     class Meta:
         name = "topobank.testing.topography_only_test"
-        display_name = "Topography-only test implementation"
+        display_name = "Measurement-only test implementation"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
 
@@ -163,10 +163,10 @@ class SecondTestImplementation(WorkflowImplementation):
         display_name = "Second test implementation"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
-        dependencies = {Topography: "topography_dependencies"}
+        dependencies = {Measurement: "topography_dependencies"}
 
     class Parameters(WorkflowImplementation.Parameters):
         c: int = 1
@@ -214,7 +214,7 @@ class TestImplementationWithError(WorkflowImplementation):
         display_name = "Test implementation with error"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
     class Parameters(WorkflowImplementation.Parameters):
@@ -243,10 +243,10 @@ class TestImplementationWithErrorInDependency(WorkflowImplementation):
         display_name = "Test implementation with error in dependency"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
-        dependencies = {Topography: "topography_dependencies"}
+        dependencies = {Measurement: "topography_dependencies"}
 
     class Parameters(WorkflowImplementation.Parameters):
         c: int = 1
@@ -299,7 +299,7 @@ class TestImplementationWithOutputs(WorkflowImplementation):
         display_name = "Test implementation with outputs"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
     class Parameters(WorkflowImplementation.Parameters):
@@ -342,10 +342,10 @@ class TestImplementationWithIntegerKeys(WorkflowImplementation):
         display_name = "Test implementation with integer keys"
 
         implementations = {
-            Topography: "topography_implementation",
+            Measurement: "topography_implementation",
         }
 
-        dependencies = {Topography: "topography_dependencies"}
+        dependencies = {Measurement: "topography_dependencies"}
 
     class Parameters(WorkflowImplementation.Parameters):
         value: int = 42


### PR DESCRIPTION
PR 1 of the series splitting #1366 into separately reviewable pieces, following #1385. This is the **pure rename** — no behaviour change, no new architecture (plus one bug fix found in review, below).

**Targets the `26_measurement_model` feature branch**, not `main`. The whole series collects there and the feature branch merges to `main` in one go. It opens the `2.0.0` CHANGELOG section, because this is where the compatibility break lands.

## What changes

- `Topography` → `Measurement`
- `Surface.topography_set` → `Surface.measurements`
- `num_topographies()` → `num_measurements()`, `num_topographies_excluding_publications()` likewise
- `WorkflowResult.subject_topography` → `subject_measurement` (and `_id` / `__` lookups)
- `TopographyAnalysisFactory` → `MeasurementAnalysisFactory`, `FailedTopographyAnalysisFactory` likewise. The `subject_measurement=` kwarg rename already touches every call site, so renaming the class in the same pass avoids editing those lines twice.
- The search-index signal receivers bound to `sender=Measurement`
- `TopographyAdmin` → `MeasurementAdmin`

## Migrations

**`manager/0084`** renames the model and rewrites its `django_content_type` row **in place**. `RenameModel` does not touch that table, and notifications reach a measurement through a generic foreign key — leaving the row alone would orphan them. Updating it rather than letting `get_for_model` create a new one preserves its primary key, and with it every existing generic reference. Reversible.

**`analysis/0066`** renames the `WorkflowResult` foreign key. A rename rather than a drop-and-add: the column holds the subject of every measurement-level analysis ever computed.

## One real bug, found in review

`SubjectTypeFilter` in `analysis/admin.py` builds its lookup key as `f"subject_{value}__isnull"`, so `"topography"` was never a display label — it was half of a field name. The rename left it pointing at a column that no longer exists, and selecting the filter in the admin raised `FieldError`.

This is the class of thing a mechanical rename cannot catch: the string `subject_topography__isnull` never appears in the source, so it is invisible to a search for the old name. The filter had no test at all, which is why it broke silently — `tests/analysis/test_admin.py` now covers it, and its lookup test reads the values from `lookups()` rather than listing them, since listing them would re-encode the very assumption the bug rested on. Verified against the bug, not just for passing: restoring `"topography"` fails three of the five tests.

I swept the rest of the codebase for the same pattern afterwards. That line was the **only** place anything composes a Django field name or attribute name from a string fragment. The one adjacent family, `getattr(self, name) for name in self._significant_fields`, holds only physical column names, which this PR does not touch.

## What deliberately keeps saying "topography"

Worth stating explicitly, since a reviewer will notice each of them:

| Kept | Why |
| --- | --- |
| The subject-type tag inside `subject_hash` | Opaque, never shown to a user. Rewriting it would invalidate the hash of every existing measurement-level result. All three sites that compute it agree, which is the property that matters, and two existing tests pin the literal. |
| Index names (`topography_surface_idx`, …) | Database-internal. Renaming them is cosmetic DDL on a large table. |
| `manifest.topography_datafiles` and friends | Renaming these pulls the `files` app forward in the migration graph, which then makes the `analysis` app's `folder` field require an unrelated `AlterField`. Nothing about the model rename needs it. |
| `Topography1DFactory` / `Topography2DFactory` | These name the *dimensionality* of the data. A later PR replaces them with kind-specific factories, so renaming them here would mean renaming them twice. |

Also untouched: local variables and test names using `topography`, the container format's `topographies` key and `TopographyMeta` schema (that is the container-format PR), and `SurfaceTopography`'s own `Topography` class — `topobank/testing/fixtures.py` and `tests/manager/test_detrend_parameters.py` import it, and were excluded from the rename.

## Verification

- `flake8` clean
- `makemigrations --check --dry-run` clean, so model state and migrations agree
- **363 passed, 4 skipped**

On the rename commit alone, `--collect-only` reported the same 362 tests as `main` — nothing lost or quietly added in the substitution. That is necessary but, as the admin bug shows, not sufficient: a code path with no test cannot move the count either way, so the count matching is evidence about the substitution, not about coverage.

## Note on versioning

`pyproject.toml` uses `hatch-vcs`, so the version comes from the git tag — there is no version string to edit. Per the agreed plan the whole series lands in one `2.0.0`: this PR opens the section and the later PRs append to it, so downstream consumers (ce-ui in particular) update once rather than across two majors.

Next in the series: pluggable measurement kinds, with metadata still in typed columns.