### PR TITLE
ENH: Record what kind of measurement a record holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # 2.0.0 (unreleased)
 
+- ENH: The kind of data a measurement holds is now recorded explicitly, in
+  `Measurement.kind`, and a registry of measurement types decides how a record of
+  that kind is read and which derived artifacts it has. An external package can
+  register its own type through the `topobank.measurement_types` entry point,
+  which is what makes non-height data possible. Measurements whose kind has no
+  registered type -- because the package providing it is not installed -- stay
+  listable, downloadable and deletable; only reading their data is refused.
 - API: `Topography` is now `Measurement`. The model records a measurement --
   identity, permissions, files and task state -- rather than something specific to
   topography data; every measurement still holds height data, so this release only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 # 2.0.0 (unreleased)
 
 - ENH: The kind of data a measurement holds is now recorded explicitly, in
-  `Measurement.kind`, and a registry of measurement types decides how a record of
-  that kind is read and which derived artifacts it has. An external package can
-  register its own type through the `topobank.measurement_types` entry point,
-  which is what makes non-height data possible. Measurements whose kind has no
-  registered type -- because the package providing it is not installed -- stay
-  listable, downloadable and deletable; only reading their data is refused.
+  `Measurement.kind`, and a registry of measurement handlers decides how a record
+  of that kind is read and which derived artifacts it has. An external package can
+  register its own handler through the `topobank.measurement_handlers` entry
+  point, which is what makes non-height data possible. Measurements whose kind has
+  no registered handler -- because the package providing it is not installed --
+  stay listable, downloadable and deletable; only reading their data is refused.
 - API: `Topography` is now `Measurement`. The model records a measurement --
   identity, permissions, files and task state -- rather than something specific to
   topography data; every measurement still holds height data, so this release only

--- a/test_settings.py
+++ b/test_settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
     "topobank.testing.mock_auth.authorization.apps.AuthorizationAppConfig",
     "topobank.files.apps.FilesAppConfig",
     "topobank.manager.apps.ManagerAppConfig",
+    "topobank.measurements.apps.MeasurementsAppConfig",
     "topobank.analysis.apps.AnalysisAppConfig",
     "topobank.testing.mock_auth.organizations.apps.OrganizationsAppConfig",
     "topobank.properties.apps.PropertiesAppConfig",

--- a/tests/measurements/test_backfill_kind.py
+++ b/tests/measurements/test_backfill_kind.py
@@ -1,0 +1,93 @@
+"""
+Tests for the `kind` backfill in `manager.0086`.
+
+The migration reconstructs the kind of every already-inspected measurement from
+the typed columns, because reopening every stored data file would be far too slow.
+The rules it uses are tested here directly against the same column combinations,
+so that a change to either the rules or the columns they read has to be
+deliberate.
+"""
+
+import importlib
+
+import pytest
+
+from topobank.manager.models import Measurement
+from topobank.testing.factories import Topography1DFactory
+
+# The module name starts with a digit, so it cannot be imported with `from ...
+# import`.
+backfill_module = importlib.import_module(
+    "topobank.manager.migrations.0086_backfill_measurement_kind"
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "resolution_x,resolution_y,is_periodic_editable,expected",
+    [
+        # Two-dimensional data: `resolution_y` is set only for maps.
+        (128, 128, True, "topography-map"),
+        # One-dimensional, periodicity still offered -> uniform.
+        (128, None, True, "uniform-line-scan"),
+        # One-dimensional, periodicity withdrawn -> non-uniform. Inspection clears
+        # the flag only for non-uniform data, which is what makes it usable here.
+        (128, None, False, "nonuniform-line-scan"),
+        # Never inspected: no resolution was ever written, so nothing can be said.
+        (None, None, True, None),
+    ],
+)
+def test_the_backfill_reconstructs_the_kind_from_the_columns(
+    resolution_x, resolution_y, is_periodic_editable, expected
+):
+    measurement = Topography1DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(
+        kind=None,
+        resolution_x=resolution_x,
+        resolution_y=resolution_y,
+        is_periodic_editable=is_periodic_editable,
+    )
+
+    backfill_module.backfill_kind(_Apps(), None)
+
+    assert Measurement.objects.get(pk=measurement.pk).kind == expected
+
+
+@pytest.mark.django_db
+def test_the_backfill_leaves_an_existing_kind_alone():
+    """
+    Only null kinds are filled in.
+
+    A measurement created by a plugin carries a kind the column rules know nothing
+    about; overwriting it with an inferred one would mislabel the data.
+    """
+    measurement = Topography1DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(kind="plugin-kind")
+
+    backfill_module.backfill_kind(_Apps(), None)
+
+    assert Measurement.objects.get(pk=measurement.pk).kind == "plugin-kind"
+
+
+@pytest.mark.django_db
+def test_the_backfill_can_be_undone():
+    measurement = Topography1DFactory()
+
+    backfill_module.clear_kind(_Apps(), None)
+
+    assert Measurement.objects.get(pk=measurement.pk).kind is None
+
+
+class _Apps:
+    """
+    Stands in for the historical model registry a migration is handed.
+
+    The backfill only reads columns that still exist on the current model, so
+    handing it the real one exercises the same queries without having to drive the
+    migration executor.
+    """
+
+    @staticmethod
+    def get_model(app_label, model_name):
+        assert (app_label, model_name) == ("manager", "Measurement")
+        return Measurement

--- a/tests/measurements/test_kinds.py
+++ b/tests/measurements/test_kinds.py
@@ -78,14 +78,51 @@ def test_a_first_inspection_records_what_was_inferred(mocker):
 
 
 @pytest.mark.django_db
-def test_an_uninspected_measurement_says_so_rather_than_guessing():
+def test_a_measurement_with_no_recorded_kind_is_still_readable():
+    """
+    Importing a container creates measurements that were never inspected.
+
+    Their metadata comes from the archive, not from reading the file, so no kind
+    was ever recorded -- but the data file is right there and the measurement has
+    to stay readable. The kind is derived from the file on demand.
+    """
+    measurement = Topography2DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(kind=None)
+    measurement.refresh_from_db()
+
+    assert measurement.measurement_type.Meta.name == "topography-map"
+    assert measurement.read() is not None
+    # Deriving it does not quietly record it; inspection is what stores a kind.
+    assert Measurement.objects.get(pk=measurement.pk).kind is None
+
+
+@pytest.mark.django_db
+def test_a_measurement_with_neither_kind_nor_data_file_says_so():
     measurement = Topography2DFactory()
     measurement.kind = None
+    measurement.datafile = None
 
-    with pytest.raises(MeasurementNotInspectedError, match="not been inspected"):
+    with pytest.raises(MeasurementNotInspectedError, match="derive one from"):
         measurement.measurement_type
 
     assert not measurement.has_known_kind
+
+
+@pytest.mark.django_db
+def test_the_cheap_interpretability_check_does_not_open_the_data_file(mocker):
+    """
+    `has_known_kind` is used to decide whether to offer data at all.
+
+    It answers from the recorded kind alone, so that listing many measurements
+    does not turn into one file open each.
+    """
+    measurement = Topography2DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(kind=None)
+    measurement.refresh_from_db()
+    reader = mocker.patch("topobank.manager.models.get_topography_reader")
+
+    assert not measurement.has_known_kind
+    reader.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -125,3 +162,41 @@ def test_reading_goes_through_the_registered_type(mocker):
 
     assert result == "data"
     assert read.call_args.kwargs["allow_canonical"] is False
+
+
+@pytest.mark.django_db
+def test_a_measurement_imported_from_a_container_can_be_read():
+    """
+    The end-to-end version of the case above, through the real import path.
+
+    Importing builds measurements straight from the archive's metadata without
+    ever inspecting a file, so nothing records a kind. This goes through
+    `import_container_zip` rather than nulling the column by hand, because the
+    absence of a kind there is a property of the import path and would survive a
+    fix that only made the hand-written case pass.
+    """
+    import os
+    import tempfile
+    import zipfile
+
+    from topobank.manager.export_zip import export_container_zip
+    from topobank.manager.import_zip import import_container_zip
+    from topobank.testing.factories import SurfaceFactory, UserFactory
+
+    user = UserFactory()
+    surface = SurfaceFactory(created_by=user)
+    Topography2DFactory(surface=surface)
+
+    outfile = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    export_container_zip(outfile, [surface])
+    outfile.close()
+    try:
+        with zipfile.ZipFile(outfile.name, mode="r") as archive:
+            (imported,) = import_container_zip(archive, UserFactory())
+    finally:
+        os.remove(outfile.name)
+
+    (measurement,) = imported.measurements.all()
+    assert measurement.kind is None  # never inspected
+    data = measurement.read()
+    assert len(data.nb_grid_pts) == 2

--- a/tests/measurements/test_kinds.py
+++ b/tests/measurements/test_kinds.py
@@ -1,0 +1,127 @@
+"""
+Tests for the kind a measurement is recorded as, and what follows from it.
+
+`Measurement.kind` is written while the data file is inspected and from then on
+decides which measurement type handles the record: how it is read, whether it has
+a Deep Zoom pyramid, whether its data can be interpreted at all.
+"""
+
+import pytest
+
+from topobank.manager.models import Measurement
+from topobank.measurements.registry import (
+    MeasurementNotInspectedError,
+    UnknownMeasurementKindError,
+)
+from topobank.testing.factories import Topography1DFactory, Topography2DFactory
+
+
+@pytest.mark.django_db
+def test_a_map_is_recorded_as_a_topography_map():
+    measurement = Topography2DFactory()
+
+    assert measurement.kind == "topography-map"
+    assert measurement.measurement_type.has_deepzoom
+
+
+@pytest.mark.django_db
+def test_a_line_scan_is_recorded_as_a_line_scan():
+    measurement = Topography1DFactory()
+
+    assert measurement.kind in ("uniform-line-scan", "nonuniform-line-scan")
+    # A line scan has no Deep Zoom pyramid; that is what the capability is for,
+    # rather than testing `size_y` for null somewhere.
+    assert not measurement.measurement_type.has_deepzoom
+
+
+@pytest.mark.django_db
+def test_the_kind_survives_a_reload():
+    """It is a stored column, not something recomputed on access."""
+    measurement = Topography2DFactory()
+
+    assert Measurement.objects.get(pk=measurement.pk).kind == "topography-map"
+
+
+@pytest.mark.django_db
+def test_reinspection_does_not_reinterpret_an_existing_measurement(mocker):
+    """
+    A measurement keeps the kind it was created with.
+
+    Refreshing the cache re-reads the file, and a reader that has meanwhile changed
+    its mind about a channel must not silently turn stored data into a different
+    kind of measurement. Asserted by watching `infer_kind`, because a rule that
+    merely happened to infer the same value again would pass a check on the stored
+    kind while still being wrong.
+    """
+    measurement = Topography2DFactory()
+    assert measurement.kind == "topography-map"
+    infer_kind = mocker.patch(
+        "topobank.manager.models.infer_kind", return_value="something-else"
+    )
+
+    measurement.refresh_cache()
+
+    infer_kind.assert_not_called()
+    assert Measurement.objects.get(pk=measurement.pk).kind == "topography-map"
+
+
+@pytest.mark.django_db
+def test_a_first_inspection_records_what_was_inferred(mocker):
+    """The counterpart: with no kind yet, inference decides and is stored."""
+    measurement = Topography2DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(kind=None)
+    measurement.refresh_from_db()
+
+    measurement.refresh_cache()
+
+    assert Measurement.objects.get(pk=measurement.pk).kind == "topography-map"
+
+
+@pytest.mark.django_db
+def test_an_uninspected_measurement_says_so_rather_than_guessing():
+    measurement = Topography2DFactory()
+    measurement.kind = None
+
+    with pytest.raises(MeasurementNotInspectedError, match="not been inspected"):
+        measurement.measurement_type
+
+    assert not measurement.has_known_kind
+
+
+@pytest.mark.django_db
+def test_a_measurement_from_an_uninstalled_plugin_stays_usable_as_a_record():
+    """
+    Graceful degradation: the record survives its plugin.
+
+    Only interpreting the data is blocked -- the measurement must still be
+    listable, renameable and deletable, or an uninstalled plugin would strand
+    whatever it created.
+    """
+    measurement = Topography2DFactory()
+    Measurement.objects.filter(pk=measurement.pk).update(kind="gone-with-the-plugin")
+    measurement = Measurement.objects.get(pk=measurement.pk)
+
+    assert not measurement.has_known_kind
+    with pytest.raises(UnknownMeasurementKindError, match="gone-with-the-plugin"):
+        measurement.read()
+
+    # ... but the record itself is untouched by that.
+    measurement.name = "renamed.txt"
+    measurement.save(update_fields=["name"])
+    assert Measurement.objects.get(pk=measurement.pk).name == "renamed.txt"
+    measurement.delete()
+    assert not Measurement.objects.filter(pk=measurement.pk).exists()
+
+
+@pytest.mark.django_db
+def test_reading_goes_through_the_registered_type(mocker):
+    """`Measurement.read` must dispatch rather than branch on field values."""
+    measurement = Topography2DFactory()
+    read = mocker.patch.object(
+        type(measurement.measurement_type), "read", return_value="data"
+    )
+
+    result = measurement.read(allow_squeezed=False)
+
+    assert result == "data"
+    assert read.call_args.kwargs["allow_canonical"] is False

--- a/tests/measurements/test_kinds.py
+++ b/tests/measurements/test_kinds.py
@@ -2,7 +2,7 @@
 Tests for the kind a measurement is recorded as, and what follows from it.
 
 `Measurement.kind` is written while the data file is inspected and from then on
-decides which measurement type handles the record: how it is read, whether it has
+decides which handler is used for the record: how it is read, whether it has
 a Deep Zoom pyramid, whether its data can be interpreted at all.
 """
 
@@ -21,7 +21,7 @@ def test_a_map_is_recorded_as_a_topography_map():
     measurement = Topography2DFactory()
 
     assert measurement.kind == "topography-map"
-    assert measurement.measurement_type.has_deepzoom
+    assert measurement.handler.has_deepzoom
 
 
 @pytest.mark.django_db
@@ -31,7 +31,7 @@ def test_a_line_scan_is_recorded_as_a_line_scan():
     assert measurement.kind in ("uniform-line-scan", "nonuniform-line-scan")
     # A line scan has no Deep Zoom pyramid; that is what the capability is for,
     # rather than testing `size_y` for null somewhere.
-    assert not measurement.measurement_type.has_deepzoom
+    assert not measurement.handler.has_deepzoom
 
 
 @pytest.mark.django_db
@@ -90,7 +90,7 @@ def test_a_measurement_with_no_recorded_kind_is_still_readable():
     Measurement.objects.filter(pk=measurement.pk).update(kind=None)
     measurement.refresh_from_db()
 
-    assert measurement.measurement_type.Meta.name == "topography-map"
+    assert measurement.handler.Meta.kind == "topography-map"
     assert measurement.read() is not None
     # Deriving it does not quietly record it; inspection is what stores a kind.
     assert Measurement.objects.get(pk=measurement.pk).kind is None
@@ -103,15 +103,15 @@ def test_a_measurement_with_neither_kind_nor_data_file_says_so():
     measurement.datafile = None
 
     with pytest.raises(MeasurementNotInspectedError, match="derive one from"):
-        measurement.measurement_type
+        measurement.handler
 
-    assert not measurement.has_known_kind
+    assert not measurement.has_handler
 
 
 @pytest.mark.django_db
 def test_the_cheap_interpretability_check_does_not_open_the_data_file(mocker):
     """
-    `has_known_kind` is used to decide whether to offer data at all.
+    `has_handler` is used to decide whether to offer data at all.
 
     It answers from the recorded kind alone, so that listing many measurements
     does not turn into one file open each.
@@ -121,7 +121,7 @@ def test_the_cheap_interpretability_check_does_not_open_the_data_file(mocker):
     measurement.refresh_from_db()
     reader = mocker.patch("topobank.manager.models.get_topography_reader")
 
-    assert not measurement.has_known_kind
+    assert not measurement.has_handler
     reader.assert_not_called()
 
 
@@ -138,7 +138,7 @@ def test_a_measurement_from_an_uninstalled_plugin_stays_usable_as_a_record():
     Measurement.objects.filter(pk=measurement.pk).update(kind="gone-with-the-plugin")
     measurement = Measurement.objects.get(pk=measurement.pk)
 
-    assert not measurement.has_known_kind
+    assert not measurement.has_handler
     with pytest.raises(UnknownMeasurementKindError, match="gone-with-the-plugin"):
         measurement.read()
 
@@ -155,7 +155,7 @@ def test_reading_goes_through_the_registered_type(mocker):
     """`Measurement.read` must dispatch rather than branch on field values."""
     measurement = Topography2DFactory()
     read = mocker.patch.object(
-        type(measurement.measurement_type), "read", return_value="data"
+        type(measurement.handler), "read", return_value="data"
     )
 
     result = measurement.read(allow_squeezed=False)

--- a/tests/measurements/test_registry.py
+++ b/tests/measurements/test_registry.py
@@ -1,10 +1,10 @@
 """
-Tests for the measurement-type registry.
+Tests for the measurement-handler registry.
 
 The registry is the seam that lets a package outside TopoBank add a kind of
 measurement, so what matters here is the contract it offers such a package:
 registration is keyed by a stable name, lookup fails loudly for an unknown kind,
-and which type claims a data channel is decided by the types themselves.
+and which handler claims a data channel is decided by the handlers themselves.
 """
 
 import pytest
@@ -14,24 +14,24 @@ from topobank.measurements.registry import (
     MeasurementRegistryError,
     UnknownMeasurementKindError,
     UnsupportedChannelError,
-    get_measurement_kinds,
-    get_measurement_type,
-    get_measurement_types,
-    has_measurement_type,
+    get_kinds,
+    get_handler,
+    get_handlers,
+    has_handler,
     infer_kind,
-    register_measurement_type,
-    unregister_measurement_type,
+    register_handler,
+    unregister_handler,
 )
-from topobank.measurements.types import (
-    MeasurementType,
-    NonuniformLineScanType,
-    TopographyMapType,
-    UniformLineScanType,
+from topobank.measurements.handlers import (
+    MeasurementHandler,
+    NonuniformLineScanHandler,
+    TopographyMapHandler,
+    UniformLineScanHandler,
 )
 
 
 class FakeChannel:
-    """The handful of channel attributes the built-in types look at."""
+    """The handful of channel attributes the built-in handlers look at."""
 
     def __init__(self, dim=2, unit="um", is_uniform=True, name="channel"):
         self.dim = dim
@@ -42,18 +42,18 @@ class FakeChannel:
 
 @pytest.fixture
 def registered():
-    """Register a throwaway type and remove it again afterwards."""
-    registered_names = []
+    """Register a throwaway handler and remove it again afterwards."""
+    registered_kinds = []
 
     def register(cls):
-        register_measurement_type(cls)
-        registered_names.append(cls.Meta.name)
+        register_handler(cls)
+        registered_kinds.append(cls.Meta.kind)
         return cls
 
     yield register
 
-    for name in registered_names:
-        unregister_measurement_type(name)
+    for kind in registered_kinds:
+        unregister_handler(kind)
 
 
 #
@@ -63,9 +63,9 @@ def registered():
 
 def test_a_registered_type_is_returned_as_a_singleton(registered):
     @registered
-    class Spectrum(MeasurementType):
+    class Spectrum(MeasurementHandler):
         class Meta:
-            name = "test-singleton"
+            kind = "test-singleton"
             display_name = "Test singleton"
 
         @classmethod
@@ -76,18 +76,18 @@ def test_a_registered_type_is_returned_as_a_singleton(registered):
             return None
 
     # The decorator returns the class, so it stays usable under its own name...
-    assert Spectrum.Meta.name == "test-singleton"
+    assert Spectrum.Meta.kind == "test-singleton"
     # ...while the registry holds one instance of it, handed out every time.
-    assert get_measurement_type("test-singleton") is get_measurement_type(
+    assert get_handler("test-singleton") is get_handler(
         "test-singleton"
     )
-    assert isinstance(get_measurement_type("test-singleton"), Spectrum)
+    assert isinstance(get_handler("test-singleton"), Spectrum)
 
 
 def test_a_type_without_a_name_is_refused():
-    class Nameless(MeasurementType):
+    class Nameless(MeasurementHandler):
         class Meta:
-            name = None
+            kind = None
 
         @classmethod
         def claims_channel(cls, channel):
@@ -97,14 +97,14 @@ def test_a_type_without_a_name_is_refused():
             return None
 
     with pytest.raises(MeasurementRegistryError, match="does not declare"):
-        register_measurement_type(Nameless)
+        register_handler(Nameless)
 
 
 def test_two_types_cannot_claim_the_same_kind(registered):
     @registered
-    class First(MeasurementType):
+    class First(MeasurementHandler):
         class Meta:
-            name = "test-duplicate"
+            kind = "test-duplicate"
 
         @classmethod
         def claims_channel(cls, channel):
@@ -113,9 +113,9 @@ def test_two_types_cannot_claim_the_same_kind(registered):
         def read(self, measurement, **kwargs):
             return None
 
-    class Second(MeasurementType):
+    class Second(MeasurementHandler):
         class Meta:
-            name = "test-duplicate"
+            kind = "test-duplicate"
 
         @classmethod
         def claims_channel(cls, channel):
@@ -125,16 +125,16 @@ def test_two_types_cannot_claim_the_same_kind(registered):
             return None
 
     with pytest.raises(AlreadyRegisteredError, match="already registered"):
-        register_measurement_type(Second)
+        register_handler(Second)
 
 
 def test_registering_the_same_class_twice_is_harmless(registered):
     """A module imported through two paths must not blow up at import time."""
 
     @registered
-    class Reimported(MeasurementType):
+    class Reimported(MeasurementHandler):
         class Meta:
-            name = "test-reimported"
+            kind = "test-reimported"
 
         @classmethod
         def claims_channel(cls, channel):
@@ -143,7 +143,7 @@ def test_registering_the_same_class_twice_is_harmless(registered):
         def read(self, measurement, **kwargs):
             return None
 
-    assert register_measurement_type(Reimported) is Reimported
+    assert register_handler(Reimported) is Reimported
 
 
 #
@@ -159,26 +159,26 @@ def test_an_unknown_kind_names_the_missing_package():
     created it, so it has to say which kind is missing.
     """
     with pytest.raises(UnknownMeasurementKindError) as excinfo:
-        get_measurement_type("no-such-kind")
+        get_handler("no-such-kind")
 
     assert "no-such-kind" in str(excinfo.value)
     assert "may not be installed" in str(excinfo.value)
 
 
 def test_absence_can_be_checked_without_catching():
-    assert has_measurement_type(TopographyMapType.Meta.name)
-    assert not has_measurement_type("no-such-kind")
+    assert has_handler(TopographyMapHandler.Meta.kind)
+    assert not has_handler("no-such-kind")
 
 
 def test_the_built_in_kinds_are_registered():
-    kinds = get_measurement_kinds()
+    kinds = get_kinds()
 
     assert set(kinds) >= {
         "topography-map",
         "uniform-line-scan",
         "nonuniform-line-scan",
     }
-    assert set(get_measurement_types()) == set(kinds)
+    assert set(get_handlers()) == set(kinds)
 
 
 #
@@ -189,19 +189,19 @@ def test_the_built_in_kinds_are_registered():
 @pytest.mark.parametrize(
     "channel,expected",
     [
-        (FakeChannel(dim=2), TopographyMapType),
-        (FakeChannel(dim=1, is_uniform=True), UniformLineScanType),
-        (FakeChannel(dim=1, is_uniform=False), NonuniformLineScanType),
+        (FakeChannel(dim=2), TopographyMapHandler),
+        (FakeChannel(dim=1, is_uniform=True), UniformLineScanHandler),
+        (FakeChannel(dim=1, is_uniform=False), NonuniformLineScanHandler),
     ],
 )
 def test_a_height_channel_is_claimed_by_exactly_one_built_in_type(channel, expected):
-    assert infer_kind(channel) == expected.Meta.name
+    assert infer_kind(channel) == expected.Meta.kind
     # Exactly one: the others must not claim it, or the result would depend on
     # registration order.
     claiming = [
-        measurement_type
-        for measurement_type in get_measurement_types().values()
-        if measurement_type.claims_channel(channel)
+        handler
+        for handler in get_handlers().values()
+        if handler.claims_channel(channel)
     ]
     assert len(claiming) == 1
 
@@ -210,7 +210,7 @@ def test_a_channel_that_is_not_height_data_is_claimed_by_nobody():
     """
     A tuple unit means the data is not a height (adhesion, current, ...).
 
-    Such channels are listed in a file's inventory but no built-in type can import
+    Such channels are listed in a file's inventory but no built-in handler can import
     them, which is exactly the gap an external plugin fills.
     """
     channel = FakeChannel(dim=2, unit=("um", "nN"), name="adhesion")
@@ -224,9 +224,9 @@ def test_a_plugin_type_can_claim_a_channel_the_built_ins_reject(registered):
     channel = FakeChannel(dim=2, unit=("um", "nN"), name="adhesion")
 
     @registered
-    class AdhesionMap(MeasurementType):
+    class AdhesionMap(MeasurementHandler):
         class Meta:
-            name = "test-adhesion-map"
+            kind = "test-adhesion-map"
 
         @classmethod
         def claims_channel(cls, other):

--- a/tests/measurements/test_registry.py
+++ b/tests/measurements/test_registry.py
@@ -1,0 +1,243 @@
+"""
+Tests for the measurement-type registry.
+
+The registry is the seam that lets a package outside TopoBank add a kind of
+measurement, so what matters here is the contract it offers such a package:
+registration is keyed by a stable name, lookup fails loudly for an unknown kind,
+and which type claims a data channel is decided by the types themselves.
+"""
+
+import pytest
+
+from topobank.measurements.registry import (
+    AlreadyRegisteredError,
+    MeasurementRegistryError,
+    UnknownMeasurementKindError,
+    UnsupportedChannelError,
+    get_measurement_kinds,
+    get_measurement_type,
+    get_measurement_types,
+    has_measurement_type,
+    infer_kind,
+    register_measurement_type,
+    unregister_measurement_type,
+)
+from topobank.measurements.types import (
+    MeasurementType,
+    NonuniformLineScanType,
+    TopographyMapType,
+    UniformLineScanType,
+)
+
+
+class FakeChannel:
+    """The handful of channel attributes the built-in types look at."""
+
+    def __init__(self, dim=2, unit="um", is_uniform=True, name="channel"):
+        self.dim = dim
+        self.unit = unit
+        self.is_uniform = is_uniform
+        self.name = name
+
+
+@pytest.fixture
+def registered():
+    """Register a throwaway type and remove it again afterwards."""
+    registered_names = []
+
+    def register(cls):
+        register_measurement_type(cls)
+        registered_names.append(cls.Meta.name)
+        return cls
+
+    yield register
+
+    for name in registered_names:
+        unregister_measurement_type(name)
+
+
+#
+# Registration
+#
+
+
+def test_a_registered_type_is_returned_as_a_singleton(registered):
+    @registered
+    class Spectrum(MeasurementType):
+        class Meta:
+            name = "test-singleton"
+            display_name = "Test singleton"
+
+        @classmethod
+        def claims_channel(cls, channel):
+            return False
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    # The decorator returns the class, so it stays usable under its own name...
+    assert Spectrum.Meta.name == "test-singleton"
+    # ...while the registry holds one instance of it, handed out every time.
+    assert get_measurement_type("test-singleton") is get_measurement_type(
+        "test-singleton"
+    )
+    assert isinstance(get_measurement_type("test-singleton"), Spectrum)
+
+
+def test_a_type_without_a_name_is_refused():
+    class Nameless(MeasurementType):
+        class Meta:
+            name = None
+
+        @classmethod
+        def claims_channel(cls, channel):
+            return False
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    with pytest.raises(MeasurementRegistryError, match="does not declare"):
+        register_measurement_type(Nameless)
+
+
+def test_two_types_cannot_claim_the_same_kind(registered):
+    @registered
+    class First(MeasurementType):
+        class Meta:
+            name = "test-duplicate"
+
+        @classmethod
+        def claims_channel(cls, channel):
+            return False
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    class Second(MeasurementType):
+        class Meta:
+            name = "test-duplicate"
+
+        @classmethod
+        def claims_channel(cls, channel):
+            return False
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    with pytest.raises(AlreadyRegisteredError, match="already registered"):
+        register_measurement_type(Second)
+
+
+def test_registering_the_same_class_twice_is_harmless(registered):
+    """A module imported through two paths must not blow up at import time."""
+
+    @registered
+    class Reimported(MeasurementType):
+        class Meta:
+            name = "test-reimported"
+
+        @classmethod
+        def claims_channel(cls, channel):
+            return False
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    assert register_measurement_type(Reimported) is Reimported
+
+
+#
+# Lookup
+#
+
+
+def test_an_unknown_kind_names_the_missing_package():
+    """
+    The message is the whole point of the error.
+
+    It is what an administrator sees when a measurement outlives the plugin that
+    created it, so it has to say which kind is missing.
+    """
+    with pytest.raises(UnknownMeasurementKindError) as excinfo:
+        get_measurement_type("no-such-kind")
+
+    assert "no-such-kind" in str(excinfo.value)
+    assert "may not be installed" in str(excinfo.value)
+
+
+def test_absence_can_be_checked_without_catching():
+    assert has_measurement_type(TopographyMapType.Meta.name)
+    assert not has_measurement_type("no-such-kind")
+
+
+def test_the_built_in_kinds_are_registered():
+    kinds = get_measurement_kinds()
+
+    assert set(kinds) >= {
+        "topography-map",
+        "uniform-line-scan",
+        "nonuniform-line-scan",
+    }
+    assert set(get_measurement_types()) == set(kinds)
+
+
+#
+# Inferring the kind of a channel
+#
+
+
+@pytest.mark.parametrize(
+    "channel,expected",
+    [
+        (FakeChannel(dim=2), TopographyMapType),
+        (FakeChannel(dim=1, is_uniform=True), UniformLineScanType),
+        (FakeChannel(dim=1, is_uniform=False), NonuniformLineScanType),
+    ],
+)
+def test_a_height_channel_is_claimed_by_exactly_one_built_in_type(channel, expected):
+    assert infer_kind(channel) == expected.Meta.name
+    # Exactly one: the others must not claim it, or the result would depend on
+    # registration order.
+    claiming = [
+        measurement_type
+        for measurement_type in get_measurement_types().values()
+        if measurement_type.claims_channel(channel)
+    ]
+    assert len(claiming) == 1
+
+
+def test_a_channel_that_is_not_height_data_is_claimed_by_nobody():
+    """
+    A tuple unit means the data is not a height (adhesion, current, ...).
+
+    Such channels are listed in a file's inventory but no built-in type can import
+    them, which is exactly the gap an external plugin fills.
+    """
+    channel = FakeChannel(dim=2, unit=("um", "nN"), name="adhesion")
+
+    with pytest.raises(UnsupportedChannelError, match="adhesion"):
+        infer_kind(channel)
+
+
+def test_a_plugin_type_can_claim_a_channel_the_built_ins_reject(registered):
+    """The registry must not need editing for a new modality to be importable."""
+    channel = FakeChannel(dim=2, unit=("um", "nN"), name="adhesion")
+
+    @registered
+    class AdhesionMap(MeasurementType):
+        class Meta:
+            name = "test-adhesion-map"
+
+        @classmethod
+        def claims_channel(cls, other):
+            return isinstance(other.unit, tuple) and other.unit[1] == "nN"
+
+        def read(self, measurement, **kwargs):
+            return None
+
+    assert infer_kind(channel) == "test-adhesion-map"
+
+
+def test_a_dimension_no_type_handles_is_rejected():
+    with pytest.raises(UnsupportedChannelError):
+        infer_kind(FakeChannel(dim=3))

--- a/topobank/manager/migrations/0085_measurement_kind.py
+++ b/topobank/manager/migrations/0085_measurement_kind.py
@@ -1,9 +1,9 @@
 """
 Add `Measurement.kind`.
 
-The column records which registered measurement type handles a record. It stays
-null for measurements whose data file has not been inspected yet; `0086` fills it
-in for those that have.
+The column records which registered measurement handler is used for a record. It
+stays null for measurements whose data file has not been inspected yet; `0086`
+fills it in for those that have.
 """
 
 from django.db import migrations, models

--- a/topobank/manager/migrations/0085_measurement_kind.py
+++ b/topobank/manager/migrations/0085_measurement_kind.py
@@ -1,0 +1,24 @@
+"""
+Add `Measurement.kind`.
+
+The column records which registered measurement type handles a record. It stays
+null for measurements whose data file has not been inspected yet; `0086` fills it
+in for those that have.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("manager", "0084_rename_topography_measurement"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="measurement",
+            name="kind",
+            field=models.TextField(blank=True, editable=False, null=True),
+        ),
+    ]

--- a/topobank/manager/migrations/0086_backfill_measurement_kind.py
+++ b/topobank/manager/migrations/0086_backfill_measurement_kind.py
@@ -1,0 +1,58 @@
+"""
+Backfill `Measurement.kind` for measurements that have already been inspected.
+
+The kind is normally derived from the selected channel while the data file is
+inspected, but reopening every stored file here would be far too slow. The values
+inspection already wrote to the typed columns are enough to reconstruct it:
+
+* ``resolution_y`` is set only for two-dimensional data, so a non-null value means
+  the record is a topography map.
+* ``is_periodic_editable`` is cleared only for non-uniform data (periodicity is
+  meaningless there), so among the one-dimensional records it separates the
+  non-uniform line scans from the uniform ones.
+
+``resolution_x`` is written on every inspection, so a null there means the file has
+never been inspected. Those rows keep a null kind and get one the first time they
+are inspected -- which is also what happens to a record whose file could not be
+read.
+
+Done in three queryset updates rather than row by row: this runs over every
+measurement in the database.
+"""
+
+from django.db import migrations
+
+# Registry keys, spelled out rather than imported. A migration has to keep
+# describing the past even if the registry's built-in types are renamed or removed.
+TOPOGRAPHY_MAP = "topography-map"
+UNIFORM_LINE_SCAN = "uniform-line-scan"
+NONUNIFORM_LINE_SCAN = "nonuniform-line-scan"
+
+
+def backfill_kind(apps, schema_editor):
+    Measurement = apps.get_model("manager", "Measurement")
+    inspected = Measurement.objects.filter(resolution_x__isnull=False, kind__isnull=True)
+
+    inspected.filter(resolution_y__isnull=False).update(kind=TOPOGRAPHY_MAP)
+    inspected.filter(resolution_y__isnull=True, is_periodic_editable=False).update(
+        kind=NONUNIFORM_LINE_SCAN
+    )
+    inspected.filter(resolution_y__isnull=True, is_periodic_editable=True).update(
+        kind=UNIFORM_LINE_SCAN
+    )
+
+
+def clear_kind(apps, schema_editor):
+    Measurement = apps.get_model("manager", "Measurement")
+    Measurement.objects.update(kind=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("manager", "0085_measurement_kind"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_kind, clear_kind),
+    ]

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -2,18 +2,13 @@
 Basic models for the web app for handling topography data.
 """
 
-import io
 import itertools
 import logging
-import os.path
-import tempfile
 from collections import defaultdict
 from typing import List
 
 import django.dispatch
-import matplotlib
 import numpy as np
-import PIL
 import tagulous.models as tm
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -21,12 +16,10 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVector, SearchVectorField
 from django.core.exceptions import PermissionDenied
 from django.core.files import File
-from django.core.files.base import ContentFile
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
 from django.db.models import Q, Value
 from django.utils import timezone
-from matplotlib.figure import Figure
 from SurfaceTopography.Container.SurfaceContainer import SurfaceContainer
 from SurfaceTopography.Exceptions import UndefinedDataError
 from SurfaceTopography.IO import ReaderBase
@@ -42,12 +35,21 @@ from ..authorization.models import (
 )
 from ..files.models import Manifest, ManifestSet
 from ..taskapp.models import IncompleteMetadataError, TaskStateModel
-from ..taskapp.utils import in_celery_worker_process, run_task
+from ..taskapp.utils import run_task
+from ..measurements.registry import (
+    MeasurementNotInspectedError,
+    get_measurement_type,
+    has_measurement_type,
+    infer_kind,
+)
+from ..measurements.types import (
+    write_canonical_manifest,
+    write_thumbnail_manifest,
+)
 from ..utils.timer import Timer
 from .utils import (
     detrend_parameters,
     get_topography_reader,
-    render_deepzoom,
     undefined_data_fraction,
 )
 
@@ -799,6 +801,17 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
     )
     channel_names = models.JSONField(default=list)
     data_source = models.IntegerField(null=True)  # Channel index
+
+    #
+    # Kind of measurement
+    #
+    # Registry key of the measurement type that handles this record; see
+    # `topobank.measurements`. Null until the data file has been inspected, since
+    # the kind is derived from the selected channel. A value with no registered
+    # type means the plugin that created the measurement is not installed: the
+    # record stays listable, downloadable and deletable, but its data cannot be
+    # read.
+    kind = models.TextField(null=True, blank=True, editable=False)
     # Django documentation discourages the use of null=True on a CharField. We use it
     # here nevertheless, because we need this values as argument to a function where
     # None has a special meaning (autodetection of format). If we used an empty string
@@ -1082,61 +1095,41 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
             }
         }
 
+    @property
+    def measurement_type(self):
+        """
+        The measurement type that handles this record.
+
+        Raises
+        ------
+        MeasurementNotInspectedError
+            If the data file has not been inspected yet, so no kind is known.
+        UnknownMeasurementKindError
+            If no type is registered for this measurement's kind, i.e. the package
+            providing it is not installed.
+        """
+        if self.kind is None:
+            raise MeasurementNotInspectedError(
+                f"Measurement {self.id} has not been inspected yet, so the kind of "
+                "measurement it holds is not known."
+            )
+        return get_measurement_type(self.kind)
+
+    @property
+    def has_known_kind(self):
+        """Whether this measurement's data can be interpreted at all."""
+        return self.kind is not None and has_measurement_type(self.kind)
+
     def _read(self, reader: ReaderBase, apply_filters: bool = True):
         """
-        Construct kwargs for reading topography given channel information.
+        Read the data object from an already opened reader.
 
-        apply_filters: bool, optional
-            If True (default), the instance is detrended and corrected for
-            missing artifacts according to the saved parameters.
-            (Default: True)
+        Kept as a thin wrapper because callers outside this class use it; the work
+        belongs to the measurement type, which knows what the data looks like.
         """
-        if not in_celery_worker_process() and self.size_y is not None:
-            _log.warning(
-                "You are requesting to load a (2D) topography and you are not within in a Celery worker "
-                "process. This operation is potentially slow and may require a lot of memory - do not use "
-                "`Measurement.read` within the main Django server!"
-            )
-
-        reader_kwargs = dict(channel_index=self.data_source, periodic=self.is_periodic)
-
-        channel = reader.channels[
-            reader.default_channel.index if self.data_source is None else self.data_source]
-
-        # Set size if physical size was not given in datafile
-        # (see also  TopographyCreateWizard.get_form_initial)
-        # Physical size is always a tuple or None.
-        if channel.physical_sizes is None:
-            if self.size_y is None:
-                reader_kwargs["physical_sizes"] = (self.size_x,)
-            else:
-                reader_kwargs["physical_sizes"] = self.size_x, self.size_y
-
-        if channel.height_scale_factor is None and self.height_scale:
-            # Adjust height scale to value chosen by user
-            reader_kwargs["height_scale_factor"] = self.height_scale
-
-            # This is only possible and needed, if no height scale was given in the data file already.
-            # So default is to use the factor from the file.
-
-        # Set the unit, if not already given by file contents
-        if channel.unit is None:
-            reader_kwargs["unit"] = self.unit
-
-        # Populate instrument information
-        reader_kwargs["info"] = self.instrument_info
-
-        # Eventually get topography from module "SurfaceTopography" using the given keywords
-        topo = reader.topography(**reader_kwargs)
-        if apply_filters:
-            if (
-                self.fill_undefined_data_mode
-                != Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING
-                and topo.is_uniform
-            ):
-                topo = topo.interpolate_undefined_data(self.fill_undefined_data_mode)
-            topo = topo.detrend(detrend_mode=self.detrend_mode)
-        return topo
+        return self.measurement_type.read_from_reader(
+            self, reader, apply_filters=apply_filters
+        )
 
     def read(
         self,
@@ -1144,24 +1137,23 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         apply_filters: bool = True,
         return_reader: bool = False,
     ):
-        """Return a SurfaceTopography.Topography/UniformLineScan/NonuniformLineScan instance.
+        """Return the in-memory data object for this measurement.
 
-        This instance is guaranteed to
+        For the height-data kinds this is a
+        SurfaceTopography.Topography/UniformLineScan/NonuniformLineScan instance,
+        guaranteed to
 
         - have a 'unit' property
         - have a size: .physical_sizes
         - have been scaled and detrended with the saved parameters
 
-        It has not necessarily a pipeline with all these steps
-        and a 'detrend_mode` attribute.
+        It has not necessarily a pipeline with all these steps and a
+        'detrend_mode` attribute. This is only always the case if
+        allow_squeezed=False. In this case the returned instance was regenerated
+        from the original file with additional steps applied.
 
-        This is only always the case
-        if allow_squeezed=False. In this case the returned instance
-        was regenerated from the original file with additional steps
-        applied.
-
-        If allow_squeezed=True, the returned topography may be read
-        from a cached file which scaling and detrending already applied.
+        If allow_squeezed=True, the returned data may be read from a cached file
+        which scaling and detrending already applied.
 
         Parameters
         ----------
@@ -1175,51 +1167,22 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
             missing artifacts according to the saved parameters.
             (Default: True)
         return_reader: bool
-            If True, return a tuple containing the topography and the reader.
+            If True, return a tuple containing the data object and the reader.
             (Default: False)
+
+        Raises
+        ------
+        MeasurementNotInspectedError
+            If the data file has not been inspected yet.
+        UnknownMeasurementKindError
+            If the package providing this kind of measurement is not installed.
         """
-        #
-        # Try to get topography from cache if possible
-        #
-        toporeader = None
-        topo = None
-        if allow_squeezed and self.squeezed_datafile_id and apply_filters:
-            if not in_celery_worker_process() and self.size_y is not None:
-                _log.warning(
-                    "You are requesting to load a (2D) topography and you are not within in a Celery worker "
-                    "process. This operation is potentially slow and may require a lot of memory - do not use "
-                    "`Measurement.read` within the main Django server!"
-                )
-
-            # Okay, we can use the squeezed datafile, it's already there.
-            toporeader = get_topography_reader(
-                self.squeezed_datafile.file, format=SQUEEZED_DATAFILE_FORMAT
-            )
-            topo = toporeader.topography(info=self.instrument_info)
-            # In the squeezed format, these things are already applied/included:
-            # unit, scaling, detrending, physical sizes
-            # so don't need to provide them to the .topography() method
-            _log.info(
-                f"Using squeezed datafile instead of original datafile for topography id {self.id}."
-            )
-
-        # Need to call exists to finish upload if file is None
-        if topo is None:
-            if self.datafile.exists():
-                # Read raw file if squeezed file is unavailable
-                toporeader = get_topography_reader(
-                    self.datafile.file, format=self.datafile_format
-                )
-                topo = self._read(toporeader, apply_filters=apply_filters)
-            else:
-                raise RuntimeError(
-                    f"Measurement {self.id} does not appear to have a data file."
-                )
-
-        if return_reader:
-            return topo, toporeader
-        else:
-            return topo
+        return self.measurement_type.read(
+            self,
+            allow_canonical=allow_squeezed,
+            apply_filters=apply_filters,
+            return_reader=return_reader,
+        )
 
     lazy_read = read  # For compatibility with datasets that implement `lazy_read`
     topography = read  # Renaming this, mark `topography` as deprecated before v2
@@ -1318,7 +1281,9 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         height : int, optional
             Maximum height of the thumbnail. (Default: 400)
         cmap : str or colormap, optional
-            Color map for rendering the topography. (Default: None)
+            Color map for rendering the data. (Default: None)
+        st_topo : optional
+            Already-read data object, to avoid reading it twice. (Default: None)
 
         Returns
         -------
@@ -1326,58 +1291,10 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
             Thumbnail image.
         """
         if st_topo is None:
-            st_topo = self.read()  # SurfaceTopography instance (=st)
-        image_file = io.BytesIO()
-        if st_topo.dim == 1:
-            dpi = 100
-            # Use the object-oriented API rather than `pyplot`. `pyplot` resolves
-            # the interactive backend, which on macOS is `macosx`; instantiating
-            # its canvas inside a forked Celery worker initializes AppKit on the
-            # child side of a fork, which the ObjC runtime aborts with SIGABRT.
-            # A bare `Figure` renders through Agg and keeps no global state, so
-            # it also removes the need to close the figure (see issue 898).
-            fig = Figure(figsize=[width / dpi, height / dpi])
-            ax = fig.subplots()
-            x, y = st_topo.positions_and_heights()
-            ax.plot(x, y, "-")
-            ax.set_axis_off()
-            fig.savefig(
-                image_file,
-                bbox_inches="tight",
-                dpi=100,
-                format=settings.TOPOBANK_THUMBNAIL_FORMAT,
-            )
-        elif st_topo.dim == 2:
-            # Compute thumbnail size (keeping aspect ratio)
-            sx, sy = st_topo.physical_sizes
-            width2 = int(sx * height / sy)
-            height2 = int(sy * width / sx)
-            if width2 <= width:
-                width = width2
-            else:
-                height = height2
-
-            # Get heights and rescale to interval 0, 1
-            heights = st_topo.heights()
-            mx, mn = heights.max(), heights.min()
-            heights = (heights - mn) / (mx - mn)
-            # Get color map. `matplotlib.colormaps` is the pyplot-free lookup;
-            # `None` selects the default, as `pyplot.get_cmap` did.
-            if cmap is None:
-                cmap = matplotlib.colormaps[matplotlib.rcParams["image.cmap"]]
-            elif isinstance(cmap, str):
-                cmap = matplotlib.colormaps[cmap]
-            # Convert to image
-            colors = (cmap(heights.T) * 255).astype(np.uint8)
-            # Remove alpha channel before writing
-            PIL.Image.fromarray(colors[:, :, :3]).resize((width, height)).save(
-                image_file, format=settings.TOPOBANK_THUMBNAIL_FORMAT
-            )
-        else:
-            raise RuntimeError(
-                f"Don't know how to create thumbnail for topography of dimension {st_topo.dim}."
-            )
-        return image_file
+            st_topo = self.read()
+        return self.measurement_type.render_thumbnail(
+            self, st_topo, width=width, height=height, cmap=cmap
+        )
 
     def _make_thumbnail(self, st_topo=None):
         """Renews thumbnail.
@@ -1391,50 +1308,41 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
 
         image_file = self._render_thumbnail(st_topo=st_topo)
 
-        # Save the contents of in-memory file in Django image field
+        # Replace the old thumbnail only once the new one has been rendered
         if self.thumbnail is not None:
             self.thumbnail.delete()
-        filename = f"thumbnail.{settings.TOPOBANK_THUMBNAIL_FORMAT}"
-        self.thumbnail = Manifest.objects.create(
-            permissions=self.permissions, filename=filename, kind="der"
-        )
-        self.thumbnail.save_file(ContentFile(image_file.getvalue()))
+        self.thumbnail = write_thumbnail_manifest(self, image_file)
 
     def _make_deepzoom(self, st_topo=None):
         """Renew deep zoom images.
+
+        Does nothing for kinds that have no Deep Zoom representation.
 
         Returns
         -------
         None
         """
+        if not self.measurement_type.has_deepzoom:
+            return
         if st_topo is None:
             st_topo = self.read()
-        if self.size_y is not None:
-            # This is a topography (map), we need to create a Deep Zoom Image
-            if self.deepzoom is not None:
-                self.deepzoom.delete()
-            self.deepzoom = ManifestSet.objects.create(permissions=self.permissions)
-            render_deepzoom(st_topo, self.deepzoom)
+        if self.deepzoom is not None:
+            self.deepzoom.delete()
+        self.deepzoom = ManifestSet.objects.create(permissions=self.permissions)
+        self.measurement_type.make_deepzoom(self, st_topo, self.deepzoom)
 
     def _make_squeezed(self, st_topo=None, save=False):
+        """Renew the canonical ("squeezed") data file."""
+        if not self.measurement_type.has_canonical_file:
+            return
         if st_topo is None:
             st_topo = self.read(allow_squeezed=False)
-        with tempfile.NamedTemporaryFile() as tmp:
-            # Write and upload NetCDF file
-            st_topo.to_netcdf(tmp.name)
-            # Delete old squeezed file
-            if self.squeezed_datafile:
-                self.squeezed_datafile.delete()
-            # Upload new squeezed file
-            dirname, basename = os.path.split(self.datafile.filename)
-            orig_stem, orig_ext = os.path.splitext(basename)
-            squeezed_name = f"{orig_stem}-squeezed.nc"
-            self.squeezed_datafile = Manifest.objects.create(
-                permissions=self.permissions,
-                filename=squeezed_name,
-                kind="der",
-                file=File(open(tmp.name, mode="rb")),
-            )
+        new_datafile = write_canonical_manifest(self, st_topo)
+        # Delete the old file only once the new one is written, so a failure part
+        # way through leaves the usable file in place.
+        if self.squeezed_datafile:
+            self.squeezed_datafile.delete()
+        self.squeezed_datafile = new_datafile
         if save:
             self.save()
 
@@ -1648,6 +1556,14 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
 
         self.data_source = data_source
 
+        # Which kind of measurement this is follows from the selected channel, so it
+        # is recorded here rather than guessed from field values later. An existing
+        # kind is not overwritten: a measurement keeps the type that created it even
+        # if the inference would now pick a different one, so that reprocessing
+        # cannot silently reinterpret stored data.
+        if self.kind is None:
+            self.kind = infer_kind(channel)
+
         #
         # Look for necessary metadata. We override values in the database. This may be
         # necessary if the underlying reader changes (e.g. through bug fixes).
@@ -1793,13 +1709,14 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
                 missing = []
                 if self.thumbnail is None or not self.thumbnail.exists():
                     missing.append("thumbnail")
-                # deepzoom is only generated for 2D maps (size_y is not None)
-                if self.size_y is not None and (
+                # Only kinds that declare a Deep Zoom representation have one.
+                if self.measurement_type.has_deepzoom and (
                     self.deepzoom is None or len(self.deepzoom) == 0
                 ):
                     missing.append("deepzoom")
-                if self.squeezed_datafile is None or not (
-                    self.squeezed_datafile.exists()
+                if self.measurement_type.has_canonical_file and (
+                    self.squeezed_datafile is None
+                    or not self.squeezed_datafile.exists()
                 ):
                     missing.append("squeezed_datafile")
                 if missing:

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -1095,29 +1095,62 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
             }
         }
 
+    def _infer_kind_from_datafile(self):
+        """
+        Derive the kind from the data file without recording it.
+
+        A measurement created from a container carries metadata that came from the
+        archive rather than from an inspection, so it has no kind yet but is
+        perfectly readable. Deriving it here keeps such a measurement usable; the
+        next inspection is what stores the value.
+
+        Raises
+        ------
+        MeasurementNotInspectedError
+            If there is no data file to derive it from.
+        """
+        if not self.datafile_id:
+            raise MeasurementNotInspectedError(
+                f"Measurement {self.id} has neither a recorded kind nor a data file "
+                "to derive one from."
+            )
+        reader = get_topography_reader(self.datafile.file, format=self.datafile_format)
+        channel = reader.channels[
+            reader.default_channel.index
+            if self.data_source is None
+            else self.data_source
+        ]
+        return infer_kind(channel)
+
     @property
     def measurement_type(self):
         """
         The measurement type that handles this record.
 
+        Falls back to deriving the kind from the data file for a measurement that
+        has not been inspected yet -- importing a container creates exactly such
+        records, and they have to stay readable.
+
         Raises
         ------
         MeasurementNotInspectedError
-            If the data file has not been inspected yet, so no kind is known.
+            If no kind is recorded and there is no data file to derive one from.
         UnknownMeasurementKindError
             If no type is registered for this measurement's kind, i.e. the package
             providing it is not installed.
         """
-        if self.kind is None:
-            raise MeasurementNotInspectedError(
-                f"Measurement {self.id} has not been inspected yet, so the kind of "
-                "measurement it holds is not known."
-            )
-        return get_measurement_type(self.kind)
+        return get_measurement_type(
+            self.kind if self.kind is not None else self._infer_kind_from_datafile()
+        )
 
     @property
     def has_known_kind(self):
-        """Whether this measurement's data can be interpreted at all."""
+        """
+        Whether this measurement's data can be interpreted at all.
+
+        Only considers the recorded kind: this is the cheap check used to decide
+        whether a record is interpretable, so it must not open the data file.
+        """
         return self.kind is not None and has_measurement_type(self.kind)
 
     def _read(self, reader: ReaderBase, apply_filters: bool = True):

--- a/topobank/manager/models.py
+++ b/topobank/manager/models.py
@@ -38,11 +38,11 @@ from ..taskapp.models import IncompleteMetadataError, TaskStateModel
 from ..taskapp.utils import run_task
 from ..measurements.registry import (
     MeasurementNotInspectedError,
-    get_measurement_type,
-    has_measurement_type,
+    get_handler,
+    has_handler,
     infer_kind,
 )
-from ..measurements.types import (
+from ..measurements.handlers import (
     write_canonical_manifest,
     write_thumbnail_manifest,
 )
@@ -805,7 +805,7 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
     #
     # Kind of measurement
     #
-    # Registry key of the measurement type that handles this record; see
+    # Registry key of the measurement handler that handles this record; see
     # `topobank.measurements`. Null until the data file has been inspected, since
     # the kind is derived from the selected channel. A value with no registered
     # type means the plugin that created the measurement is not installed: the
@@ -1123,9 +1123,9 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         return infer_kind(channel)
 
     @property
-    def measurement_type(self):
+    def handler(self):
         """
-        The measurement type that handles this record.
+        The measurement handler that handles this record.
 
         Falls back to deriving the kind from the data file for a measurement that
         has not been inspected yet -- importing a container creates exactly such
@@ -1139,28 +1139,28 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
             If no type is registered for this measurement's kind, i.e. the package
             providing it is not installed.
         """
-        return get_measurement_type(
+        return get_handler(
             self.kind if self.kind is not None else self._infer_kind_from_datafile()
         )
 
     @property
-    def has_known_kind(self):
+    def has_handler(self):
         """
         Whether this measurement's data can be interpreted at all.
 
         Only considers the recorded kind: this is the cheap check used to decide
         whether a record is interpretable, so it must not open the data file.
         """
-        return self.kind is not None and has_measurement_type(self.kind)
+        return self.kind is not None and has_handler(self.kind)
 
     def _read(self, reader: ReaderBase, apply_filters: bool = True):
         """
         Read the data object from an already opened reader.
 
         Kept as a thin wrapper because callers outside this class use it; the work
-        belongs to the measurement type, which knows what the data looks like.
+        belongs to the handler, which knows what the data looks like.
         """
-        return self.measurement_type.read_from_reader(
+        return self.handler.read_from_reader(
             self, reader, apply_filters=apply_filters
         )
 
@@ -1210,7 +1210,7 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         UnknownMeasurementKindError
             If the package providing this kind of measurement is not installed.
         """
-        return self.measurement_type.read(
+        return self.handler.read(
             self,
             allow_canonical=allow_squeezed,
             apply_filters=apply_filters,
@@ -1325,7 +1325,7 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         """
         if st_topo is None:
             st_topo = self.read()
-        return self.measurement_type.render_thumbnail(
+        return self.handler.render_thumbnail(
             self, st_topo, width=width, height=height, cmap=cmap
         )
 
@@ -1355,18 +1355,18 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
         -------
         None
         """
-        if not self.measurement_type.has_deepzoom:
+        if not self.handler.has_deepzoom:
             return
         if st_topo is None:
             st_topo = self.read()
         if self.deepzoom is not None:
             self.deepzoom.delete()
         self.deepzoom = ManifestSet.objects.create(permissions=self.permissions)
-        self.measurement_type.make_deepzoom(self, st_topo, self.deepzoom)
+        self.handler.make_deepzoom(self, st_topo, self.deepzoom)
 
     def _make_squeezed(self, st_topo=None, save=False):
         """Renew the canonical ("squeezed") data file."""
-        if not self.measurement_type.has_canonical_file:
+        if not self.handler.has_canonical_file:
             return
         if st_topo is None:
             st_topo = self.read(allow_squeezed=False)
@@ -1743,11 +1743,11 @@ class Measurement(PermissionMixin, TaskStateModel, SubjectMixin):
                 if self.thumbnail is None or not self.thumbnail.exists():
                     missing.append("thumbnail")
                 # Only kinds that declare a Deep Zoom representation have one.
-                if self.measurement_type.has_deepzoom and (
+                if self.handler.has_deepzoom and (
                     self.deepzoom is None or len(self.deepzoom) == 0
                 ):
                     missing.append("deepzoom")
-                if self.measurement_type.has_canonical_file and (
+                if self.handler.has_canonical_file and (
                     self.squeezed_datafile is None
                     or not self.squeezed_datafile.exists()
                 ):

--- a/topobank/measurements/__init__.py
+++ b/topobank/measurements/__init__.py
@@ -1,5 +1,5 @@
 """
-Measurement types: what kind of data a measurement holds, and how to read it.
+Measurement handlers: what kind of data a measurement holds, and how to read it.
 
 The public interface is the registry; see :mod:`topobank.measurements.registry`.
 """

--- a/topobank/measurements/__init__.py
+++ b/topobank/measurements/__init__.py
@@ -1,0 +1,7 @@
+"""
+Measurement types: what kind of data a measurement holds, and how to read it.
+
+The public interface is the registry; see :mod:`topobank.measurements.registry`.
+"""
+
+default_app_config = "topobank.measurements.apps.MeasurementsAppConfig"

--- a/topobank/measurements/apps.py
+++ b/topobank/measurements/apps.py
@@ -4,15 +4,15 @@ from django.apps import AppConfig
 class MeasurementsAppConfig(AppConfig):
     name = "topobank.measurements"
     label = "measurements"
-    verbose_name = "Measurement types"
+    verbose_name = "Measurement handlers"
 
     def ready(self):
         # Importing the module registers the built-in types through the
-        # `register_measurement_type` decorator.
-        from . import types  # noqa: F401
+        # `register_handler` decorator.
+        from . import handlers  # noqa: F401
         from .registry import load_entry_points
 
         # Types shipped by external packages. Registered after the built-ins so a
-        # plugin cannot shadow one of them; `register_measurement_type` raises on a
+        # plugin cannot shadow one of them; `register_handler` raises on a
         # duplicate kind.
         load_entry_points()

--- a/topobank/measurements/apps.py
+++ b/topobank/measurements/apps.py
@@ -1,0 +1,18 @@
+from django.apps import AppConfig
+
+
+class MeasurementsAppConfig(AppConfig):
+    name = "topobank.measurements"
+    label = "measurements"
+    verbose_name = "Measurement types"
+
+    def ready(self):
+        # Importing the module registers the built-in types through the
+        # `register_measurement_type` decorator.
+        from . import types  # noqa: F401
+        from .registry import load_entry_points
+
+        # Types shipped by external packages. Registered after the built-ins so a
+        # plugin cannot shadow one of them; `register_measurement_type` raises on a
+        # duplicate kind.
+        load_entry_points()

--- a/topobank/measurements/handlers.py
+++ b/topobank/measurements/handlers.py
@@ -1,16 +1,16 @@
 """
-Measurement types.
+Measurement handlers.
 
-A :class:`MeasurementType` is the strategy that binds a stored
+A :class:`MeasurementHandler` is the strategy that binds a stored
 :class:`~topobank.manager.models.Measurement` to the in-memory *data object*
 representing its actual data. It owns everything that depends on what kind of
 measurement is being handled: which channels can be imported, how the data file
 is read, and which derived artifacts exist.
 
 The three built-in types cover height data and share
-:class:`SurfaceTopographyType`, which holds everything that goes through
+:class:`SurfaceTopographyHandler`, which holds everything that goes through
 ``SurfaceTopography.IO``. A type for an entirely different modality (an XPS
-spectrum, say) subclasses :class:`MeasurementType` directly and imports its own
+spectrum, say) subclasses :class:`MeasurementHandler` directly and imports its own
 data package; nothing in this module needs to know about it.
 
 At this stage the metadata a type needs still lives in typed columns on the model,
@@ -33,7 +33,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.base import ContentFile
 
-from .registry import register_measurement_type
+from .registry import register_handler
 
 _log = logging.getLogger(__name__)
 
@@ -41,18 +41,18 @@ _log = logging.getLogger(__name__)
 CANONICAL_DATAFILE_FORMAT = "nc"
 
 
-class MeasurementType(abc.ABC):
+class MeasurementHandler(abc.ABC):
     """
-    Base class of all measurement types.
+    Base class of all measurement handlers.
 
     Registered subclasses are instantiated once; that singleton is what
-    :func:`~topobank.measurements.registry.get_measurement_type` returns. There is
+    :func:`~topobank.measurements.registry.get_handler` returns. There is
     no per-instance state -- the measurement to work on is always passed in.
     """
 
     class Meta:
         #: Stable registry key, stored in ``Measurement.kind``. Never rename.
-        name = None
+        kind = None
         #: Human-readable name for the UI.
         display_name = None
 
@@ -72,7 +72,7 @@ class MeasurementType(abc.ABC):
     is_expensive_to_read = False
 
     def __str__(self):
-        return self.Meta.display_name or self.Meta.name
+        return self.Meta.display_name or self.Meta.kind
 
     @classmethod
     @abc.abstractmethod
@@ -139,9 +139,9 @@ class MeasurementType(abc.ABC):
         )
 
 
-class SurfaceTopographyType(MeasurementType):
+class SurfaceTopographyHandler(MeasurementHandler):
     """
-    Common base of the measurement types backed by ``SurfaceTopography``.
+    Common base of the measurement handlers backed by ``SurfaceTopography``.
 
     Everything that goes through ``SurfaceTopography.IO`` lives here: reading data
     objects and the canonical NetCDF representation. Concrete subclasses declare
@@ -303,7 +303,7 @@ class SurfaceTopographyType(MeasurementType):
         data.to_netcdf(path)
 
 
-class LineScanType(SurfaceTopographyType):
+class LineScanHandler(SurfaceTopographyHandler):
     """Common base of the one-dimensional height measurements."""
 
     dim = 1
@@ -337,12 +337,12 @@ class LineScanType(SurfaceTopographyType):
         return image_file
 
 
-@register_measurement_type
-class TopographyMapType(SurfaceTopographyType):
+@register_handler
+class TopographyMapHandler(SurfaceTopographyHandler):
     """A two-dimensional map of heights."""
 
     class Meta:
-        name = "topography-map"
+        kind = "topography-map"
         display_name = "Topography map"
 
     dim = 2
@@ -389,23 +389,23 @@ class TopographyMapType(SurfaceTopographyType):
         render_deepzoom(data, manifest_set)
 
 
-@register_measurement_type
-class UniformLineScanType(LineScanType):
+@register_handler
+class UniformLineScanHandler(LineScanHandler):
     """A line scan on an evenly spaced grid."""
 
     class Meta:
-        name = "uniform-line-scan"
+        kind = "uniform-line-scan"
         display_name = "Uniform line scan"
 
     is_uniform = True
 
 
-@register_measurement_type
-class NonuniformLineScanType(LineScanType):
+@register_handler
+class NonuniformLineScanHandler(LineScanHandler):
     """A line scan whose sample positions are arbitrary."""
 
     class Meta:
-        name = "nonuniform-line-scan"
+        kind = "nonuniform-line-scan"
         display_name = "Nonuniform line scan"
 
     is_uniform = False
@@ -425,9 +425,9 @@ def write_canonical_manifest(measurement, data):
     """
     from ..files.models import Manifest
 
-    measurement_type = measurement.measurement_type
+    handler = measurement.handler
     with tempfile.NamedTemporaryFile(suffix=f".{CANONICAL_DATAFILE_FORMAT}") as tmp:
-        measurement_type.write_canonical_file(measurement, data, tmp.name)
+        handler.write_canonical_file(measurement, data, tmp.name)
         _, basename = os.path.split(measurement.datafile.filename)
         stem, _ = os.path.splitext(basename)
         return Manifest.objects.create(

--- a/topobank/measurements/registry.py
+++ b/topobank/measurements/registry.py
@@ -1,7 +1,7 @@
 """
-Registry for measurement types.
+Registry for measurement handlers.
 
-A measurement type owns everything that depends on *what kind of measurement* is
+A measurement handler owns everything that depends on *what kind of measurement* is
 being handled: how the data file is read into an in-memory data object, which
 channels it can import, and which derived artifacts (thumbnails, Deep Zoom
 images, canonical files) exist for it.
@@ -10,19 +10,19 @@ Types are registered under a stable string key which is also stored in
 ``Measurement.kind``. Because that key ends up in the database, in exported
 containers and in published datasets, it must never be renamed once released.
 
-Built-in types are registered when :mod:`topobank.measurements.types` is imported
+Built-in types are registered when :mod:`topobank.measurements.handlers` is imported
 (see :class:`topobank.measurements.apps.MeasurementsAppConfig`). External packages
 can register their own types either from the ``ready()`` method of their own
-``AppConfig`` or through the ``topobank.measurement_types`` entry-point group.
+``AppConfig`` or through the ``topobank.measurement_handlers`` entry-point group.
 """
 
 import logging
 
 _log = logging.getLogger(__name__)
 
-#: Name of the entry-point group used to discover measurement types shipped by
+#: Name of the entry-point group used to discover measurement handlers shipped by
 #: external packages.
-ENTRY_POINT_GROUP = "topobank.measurement_types"
+ENTRY_POINT_GROUP = "topobank.measurement_handlers"
 
 
 #
@@ -31,17 +31,17 @@ ENTRY_POINT_GROUP = "topobank.measurement_types"
 
 
 class MeasurementRegistryError(Exception):
-    """Generic problem while handling measurement types."""
+    """Generic problem while handling measurement handlers."""
 
 
 class AlreadyRegisteredError(MeasurementRegistryError):
-    """A measurement type has already been registered for the given key."""
+    """A measurement handler has already been registered for the given key."""
 
     def __init__(self, name):
         self._name = name
 
     def __str__(self):
-        return f"A measurement type for kind '{self._name}' is already registered."
+        return f"A measurement handler for kind '{self._name}' is already registered."
 
 
 class MeasurementNotInspectedError(MeasurementRegistryError):
@@ -49,13 +49,13 @@ class MeasurementNotInspectedError(MeasurementRegistryError):
     The kind of a measurement is not known yet.
 
     Raised for a measurement whose data file has not been inspected, so no
-    measurement type can be determined for it.
+    measurement handler can be determined for it.
     """
 
 
 class UnknownMeasurementKindError(MeasurementRegistryError):
     """
-    No measurement type is registered for the requested kind.
+    No measurement handler is registered for the requested kind.
 
     This is what surfaces when a measurement was created by a plugin that is no
     longer installed. Such measurements stay listable, downloadable and
@@ -67,34 +67,34 @@ class UnknownMeasurementKindError(MeasurementRegistryError):
 
     def __str__(self):
         return (
-            f"No measurement type is registered for kind '{self._name}'. The "
+            f"No measurement handler is registered for kind '{self._name}'. The "
             "package providing this kind of measurement may not be installed."
         )
 
 
 class UnsupportedChannelError(MeasurementRegistryError):
-    """No registered measurement type can import this data channel."""
+    """No registered measurement handler can import this data channel."""
 
 
 #
 # Registry
 #
 
-_measurement_types = {}
+_handlers = {}
 
 
-def register_measurement_type(cls):
+def register_handler(cls):
     """
-    Register a measurement type.
+    Register a measurement handler.
 
     Can be used as a class decorator. The class is instantiated once (without
-    arguments) and that singleton is what :func:`get_measurement_type` returns;
+    arguments) and that singleton is what :func:`get_handler` returns;
     the class itself is returned so it stays usable under its own name.
 
     Parameters
     ----------
     cls : type
-        Subclass of :class:`topobank.measurements.types.MeasurementType`.
+        Subclass of :class:`topobank.measurements.handlers.MeasurementHandler`.
 
     Returns
     -------
@@ -108,25 +108,25 @@ def register_measurement_type(cls):
     AlreadyRegisteredError
         If a different type is already registered under the same name.
     """
-    name = getattr(cls.Meta, "name", None)
-    if not name:
+    kind = getattr(cls.Meta, "kind", None)
+    if not kind:
         raise MeasurementRegistryError(
-            f"Measurement type '{cls.__name__}' does not declare a `Meta.name`."
+            f"Measurement handler '{cls.__name__}' does not declare a `Meta.kind`."
         )
-    if name in _measurement_types:
-        if type(_measurement_types[name]) is cls:
+    if kind in _handlers:
+        if type(_handlers[kind]) is cls:
             # Registering the very same class twice is harmless and happens when a
             # module is imported through two different paths.
             return cls
-        raise AlreadyRegisteredError(name)
-    _measurement_types[name] = cls()
-    _log.debug("Registered measurement type '%s' (%s).", name, cls.__name__)
+        raise AlreadyRegisteredError(kind)
+    _handlers[kind] = cls()
+    _log.debug("Registered measurement handler '%s' (%s).", kind, cls.__name__)
     return cls
 
 
-def get_measurement_type(name):
+def get_handler(name):
     """
-    Return the measurement type registered for `name`.
+    Return the handler registered for `kind`.
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ def get_measurement_type(name):
 
     Returns
     -------
-    MeasurementType
+    MeasurementHandler
         The registered singleton.
 
     Raises
@@ -144,34 +144,34 @@ def get_measurement_type(name):
         If nothing is registered under this key.
     """
     try:
-        return _measurement_types[name]
+        return _handlers[name]
     except KeyError:
         raise UnknownMeasurementKindError(name)
 
 
-def has_measurement_type(name):
-    """Return True if a measurement type is registered for `name`."""
-    return name in _measurement_types
+def has_handler(name):
+    """Return True if a handler is registered for `kind`."""
+    return name in _handlers
 
 
-def get_measurement_types():
-    """Return all registered measurement types, keyed by kind."""
-    return dict(_measurement_types)
+def get_handlers():
+    """Return all registered handlers, keyed by kind."""
+    return dict(_handlers)
 
 
-def get_measurement_kinds():
-    """Return the kinds of all registered measurement types."""
-    return list(_measurement_types)
+def get_kinds():
+    """Return the kinds of all registered handlers."""
+    return list(_handlers)
 
 
-def unregister_measurement_type(name):
+def unregister_handler(name):
     """
-    Remove a measurement type from the registry.
+    Remove a handler from the registry.
 
     For tests that need to simulate an uninstalled plugin; not part of the normal
     plugin lifecycle.
     """
-    _measurement_types.pop(name, None)
+    _handlers.pop(name, None)
 
 
 def infer_kind(channel):
@@ -196,22 +196,22 @@ def infer_kind(channel):
     UnsupportedChannelError
         If no registered type can import it.
     """
-    for name, measurement_type in _measurement_types.items():
-        if measurement_type.claims_channel(channel):
+    for name, handler in _handlers.items():
+        if handler.claims_channel(channel):
             return name
     raise UnsupportedChannelError(
-        f"None of the registered measurement types "
-        f"({', '.join(_measurement_types) or 'none are registered'}) can import "
+        f"None of the registered measurement handlers "
+        f"({', '.join(_handlers) or 'none are registered'}) can import "
         f"channel '{getattr(channel, 'name', channel)}'."
     )
 
 
 def load_entry_points():
     """
-    Discover and register measurement types provided by external packages.
+    Discover and register measurement handlers provided by external packages.
 
-    Every entry point in the ``topobank.measurement_types`` group is loaded. An
-    entry point may resolve either to a ``MeasurementType`` subclass, which is
+    Every entry point in the ``topobank.measurement_handlers`` group is loaded. An
+    entry point may resolve either to a ``MeasurementHandler`` subclass, which is
     registered, or to a module, which is expected to register its own types on
     import. Failures are logged and skipped: a broken third-party plugin must not
     stop the site from starting.
@@ -223,16 +223,16 @@ def load_entry_points():
             obj = entry_point.load()
         except Exception:
             _log.exception(
-                "Failed to load measurement type from entry point '%s'.",
+                "Failed to load measurement handler from entry point '%s'.",
                 entry_point.name,
             )
             continue
         if isinstance(obj, type):
             try:
-                register_measurement_type(obj)
+                register_handler(obj)
             except MeasurementRegistryError:
                 _log.exception(
-                    "Failed to register measurement type '%s' from entry point.",
+                    "Failed to register measurement handler '%s' from entry point.",
                     entry_point.name,
                 )
         # If the entry point resolved to a module, importing it was the point: the

--- a/topobank/measurements/registry.py
+++ b/topobank/measurements/registry.py
@@ -1,0 +1,239 @@
+"""
+Registry for measurement types.
+
+A measurement type owns everything that depends on *what kind of measurement* is
+being handled: how the data file is read into an in-memory data object, which
+channels it can import, and which derived artifacts (thumbnails, Deep Zoom
+images, canonical files) exist for it.
+
+Types are registered under a stable string key which is also stored in
+``Measurement.kind``. Because that key ends up in the database, in exported
+containers and in published datasets, it must never be renamed once released.
+
+Built-in types are registered when :mod:`topobank.measurements.types` is imported
+(see :class:`topobank.measurements.apps.MeasurementsAppConfig`). External packages
+can register their own types either from the ``ready()`` method of their own
+``AppConfig`` or through the ``topobank.measurement_types`` entry-point group.
+"""
+
+import logging
+
+_log = logging.getLogger(__name__)
+
+#: Name of the entry-point group used to discover measurement types shipped by
+#: external packages.
+ENTRY_POINT_GROUP = "topobank.measurement_types"
+
+
+#
+# Exceptions
+#
+
+
+class MeasurementRegistryError(Exception):
+    """Generic problem while handling measurement types."""
+
+
+class AlreadyRegisteredError(MeasurementRegistryError):
+    """A measurement type has already been registered for the given key."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return f"A measurement type for kind '{self._name}' is already registered."
+
+
+class MeasurementNotInspectedError(MeasurementRegistryError):
+    """
+    The kind of a measurement is not known yet.
+
+    Raised for a measurement whose data file has not been inspected, so no
+    measurement type can be determined for it.
+    """
+
+
+class UnknownMeasurementKindError(MeasurementRegistryError):
+    """
+    No measurement type is registered for the requested kind.
+
+    This is what surfaces when a measurement was created by a plugin that is no
+    longer installed. Such measurements stay listable, downloadable and
+    deletable; only reading their data is blocked.
+    """
+
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return (
+            f"No measurement type is registered for kind '{self._name}'. The "
+            "package providing this kind of measurement may not be installed."
+        )
+
+
+class UnsupportedChannelError(MeasurementRegistryError):
+    """No registered measurement type can import this data channel."""
+
+
+#
+# Registry
+#
+
+_measurement_types = {}
+
+
+def register_measurement_type(cls):
+    """
+    Register a measurement type.
+
+    Can be used as a class decorator. The class is instantiated once (without
+    arguments) and that singleton is what :func:`get_measurement_type` returns;
+    the class itself is returned so it stays usable under its own name.
+
+    Parameters
+    ----------
+    cls : type
+        Subclass of :class:`topobank.measurements.types.MeasurementType`.
+
+    Returns
+    -------
+    type
+        The class that was passed in.
+
+    Raises
+    ------
+    MeasurementRegistryError
+        If the class does not declare a name.
+    AlreadyRegisteredError
+        If a different type is already registered under the same name.
+    """
+    name = getattr(cls.Meta, "name", None)
+    if not name:
+        raise MeasurementRegistryError(
+            f"Measurement type '{cls.__name__}' does not declare a `Meta.name`."
+        )
+    if name in _measurement_types:
+        if type(_measurement_types[name]) is cls:
+            # Registering the very same class twice is harmless and happens when a
+            # module is imported through two different paths.
+            return cls
+        raise AlreadyRegisteredError(name)
+    _measurement_types[name] = cls()
+    _log.debug("Registered measurement type '%s' (%s).", name, cls.__name__)
+    return cls
+
+
+def get_measurement_type(name):
+    """
+    Return the measurement type registered for `name`.
+
+    Parameters
+    ----------
+    name : str
+        Registry key, i.e. the value of ``Measurement.kind``.
+
+    Returns
+    -------
+    MeasurementType
+        The registered singleton.
+
+    Raises
+    ------
+    UnknownMeasurementKindError
+        If nothing is registered under this key.
+    """
+    try:
+        return _measurement_types[name]
+    except KeyError:
+        raise UnknownMeasurementKindError(name)
+
+
+def has_measurement_type(name):
+    """Return True if a measurement type is registered for `name`."""
+    return name in _measurement_types
+
+
+def get_measurement_types():
+    """Return all registered measurement types, keyed by kind."""
+    return dict(_measurement_types)
+
+
+def get_measurement_kinds():
+    """Return the kinds of all registered measurement types."""
+    return list(_measurement_types)
+
+
+def unregister_measurement_type(name):
+    """
+    Remove a measurement type from the registry.
+
+    For tests that need to simulate an uninstalled plugin; not part of the normal
+    plugin lifecycle.
+    """
+    _measurement_types.pop(name, None)
+
+
+def infer_kind(channel):
+    """
+    Return the kind a data channel is imported as.
+
+    Each registered type decides for itself whether it can import a channel, so
+    a type for a new modality does not require changes here.
+
+    Parameters
+    ----------
+    channel : SurfaceTopography.IO.ChannelInfo
+        A channel of an opened data file.
+
+    Returns
+    -------
+    str
+        Kind of the first registered type that claims the channel.
+
+    Raises
+    ------
+    UnsupportedChannelError
+        If no registered type can import it.
+    """
+    for name, measurement_type in _measurement_types.items():
+        if measurement_type.claims_channel(channel):
+            return name
+    raise UnsupportedChannelError(
+        f"None of the registered measurement types "
+        f"({', '.join(_measurement_types) or 'none are registered'}) can import "
+        f"channel '{getattr(channel, 'name', channel)}'."
+    )
+
+
+def load_entry_points():
+    """
+    Discover and register measurement types provided by external packages.
+
+    Every entry point in the ``topobank.measurement_types`` group is loaded. An
+    entry point may resolve either to a ``MeasurementType`` subclass, which is
+    registered, or to a module, which is expected to register its own types on
+    import. Failures are logged and skipped: a broken third-party plugin must not
+    stop the site from starting.
+    """
+    from importlib.metadata import entry_points
+
+    for entry_point in entry_points(group=ENTRY_POINT_GROUP):
+        try:
+            obj = entry_point.load()
+        except Exception:
+            _log.exception(
+                "Failed to load measurement type from entry point '%s'.",
+                entry_point.name,
+            )
+            continue
+        if isinstance(obj, type):
+            try:
+                register_measurement_type(obj)
+            except MeasurementRegistryError:
+                _log.exception(
+                    "Failed to register measurement type '%s' from entry point.",
+                    entry_point.name,
+                )
+        # If the entry point resolved to a module, importing it was the point: the
+        # module is expected to have registered its types itself.

--- a/topobank/measurements/types.py
+++ b/topobank/measurements/types.py
@@ -1,0 +1,451 @@
+"""
+Measurement types.
+
+A :class:`MeasurementType` is the strategy that binds a stored
+:class:`~topobank.manager.models.Measurement` to the in-memory *data object*
+representing its actual data. It owns everything that depends on what kind of
+measurement is being handled: which channels can be imported, how the data file
+is read, and which derived artifacts exist.
+
+The three built-in types cover height data and share
+:class:`SurfaceTopographyType`, which holds everything that goes through
+``SurfaceTopography.IO``. A type for an entirely different modality (an XPS
+spectrum, say) subclasses :class:`MeasurementType` directly and imports its own
+data package; nothing in this module needs to know about it.
+
+At this stage the metadata a type needs still lives in typed columns on the model,
+so the methods here read it off the measurement they are handed. Which fields are
+meaningful for which kind is therefore still implicit -- ``size_y`` being null is
+what makes a record a line scan. Making that explicit is the next step; this one
+only moves the kind-dependent *behaviour* out of the model.
+"""
+
+import abc
+import io
+import logging
+import os.path
+import tempfile
+
+import matplotlib
+import numpy as np
+import PIL
+from django.conf import settings
+from django.core.files import File
+from django.core.files.base import ContentFile
+
+from .registry import register_measurement_type
+
+_log = logging.getLogger(__name__)
+
+#: Format of the canonical ("squeezed") representation of height data.
+CANONICAL_DATAFILE_FORMAT = "nc"
+
+
+class MeasurementType(abc.ABC):
+    """
+    Base class of all measurement types.
+
+    Registered subclasses are instantiated once; that singleton is what
+    :func:`~topobank.measurements.registry.get_measurement_type` returns. There is
+    no per-instance state -- the measurement to work on is always passed in.
+    """
+
+    class Meta:
+        #: Stable registry key, stored in ``Measurement.kind``. Never rename.
+        name = None
+        #: Human-readable name for the UI.
+        display_name = None
+
+    #
+    # Capabilities. These tell the generic machinery which derived artifacts exist
+    # for this kind, so it does not have to infer that from field values.
+    #
+    #: Whether a Deep Zoom Image pyramid is generated.
+    has_deepzoom = False
+    #: Whether a canonical (preprocessed) representation of the data is stored.
+    has_canonical_file = False
+    #: Whether :meth:`read` returns a ``SurfaceTopography`` object, and the
+    #: measurement can therefore take part in ``SurfaceContainer`` operations.
+    yields_surface_topography = False
+    #: Whether reading the data is costly enough that doing it outside a Celery
+    #: worker deserves a warning.
+    is_expensive_to_read = False
+
+    def __str__(self):
+        return self.Meta.display_name or self.Meta.name
+
+    @classmethod
+    @abc.abstractmethod
+    def claims_channel(cls, channel) -> bool:
+        """
+        Whether this type can import `channel`.
+
+        Called while inspecting a data file, to decide which kind a measurement
+        is. Must not raise for channels it does not recognize -- an unrecognized
+        channel is simply not claimed.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def read(
+        self,
+        measurement,
+        allow_canonical: bool = True,
+        apply_filters: bool = True,
+        return_reader: bool = False,
+    ):
+        """
+        Construct the in-memory data object for `measurement`.
+
+        Parameters
+        ----------
+        measurement : Measurement
+            The measurement to read.
+        allow_canonical : bool, optional
+            Whether the cached canonical representation may be used instead of the
+            original file. (Default: True)
+        apply_filters : bool, optional
+            Whether the stored corrections (detrending, filling of undefined data)
+            are applied. (Default: True)
+        return_reader : bool, optional
+            If True, return a tuple of data object and reader. (Default: False)
+        """
+        raise NotImplementedError
+
+    #
+    # Derived artifacts. The defaults do nothing, so a type only implements what it
+    # actually supports.
+    #
+
+    def render_thumbnail(self, measurement, data, width=400, height=400, cmap=None):
+        """
+        Render a thumbnail and return it as an in-memory file.
+
+        Returning the image rather than assigning it keeps the storage plumbing --
+        which manifest to replace, which permissions to use -- in one place on the
+        model, where it is the same for every kind.
+        """
+        raise NotImplementedError(
+            f"'{self}' measurements do not support thumbnails."
+        )
+
+    def make_deepzoom(self, measurement, data, manifest_set) -> None:
+        """Render Deep Zoom images into `manifest_set`."""
+
+    def write_canonical_file(self, measurement, data, path) -> None:
+        """Write the canonical representation of `data` to `path`."""
+        raise NotImplementedError(
+            f"'{self}' measurements do not have a canonical file."
+        )
+
+
+class SurfaceTopographyType(MeasurementType):
+    """
+    Common base of the measurement types backed by ``SurfaceTopography``.
+
+    Everything that goes through ``SurfaceTopography.IO`` lives here: reading data
+    objects and the canonical NetCDF representation. Concrete subclasses declare
+    only what genuinely differs between a map and a line scan.
+    """
+
+    yields_surface_topography = True
+    has_canonical_file = True
+
+    #: Dimensionality of the data this type imports, checked by
+    #: :meth:`claims_channel`.
+    dim = None
+    #: Whether the type imports uniform data, non-uniform data, or (None) either.
+    is_uniform = None
+
+    @staticmethod
+    def channel_units(channel):
+        """
+        Return the ``(lateral_unit, data_unit)`` of a reader channel.
+
+        A scalar unit means the channel contains heights, so the lateral and data
+        units are the same. A tuple means the data is something other than a
+        height (adhesion, current, stiffness, ...).
+        """
+        if isinstance(channel.unit, tuple):
+            return channel.unit
+        return channel.unit, channel.unit
+
+    @classmethod
+    def claims_channel(cls, channel):
+        lateral_unit, data_unit = cls.channel_units(channel)
+        if lateral_unit != data_unit:
+            # Not height data, so none of the built-in types can import it.
+            return False
+        if channel.dim != cls.dim:
+            return False
+        return cls.is_uniform is None or bool(channel.is_uniform) == cls.is_uniform
+
+    #
+    # Reading data
+    #
+
+    def read(
+        self,
+        measurement,
+        allow_canonical: bool = True,
+        apply_filters: bool = True,
+        return_reader: bool = False,
+    ):
+        # Imported here rather than at module level: this module is imported while
+        # apps load, and `manager` pulls in the model layer.
+        from ..manager.utils import get_topography_reader
+
+        reader = None
+        data = None
+
+        if (
+            allow_canonical
+            and apply_filters
+            and self.has_canonical_file
+            and measurement.squeezed_datafile_id
+        ):
+            self._warn_if_expensive(measurement)
+            # The canonical file already has unit, scaling, detrending and physical
+            # sizes applied, so none of them are passed here.
+            reader = get_topography_reader(
+                measurement.squeezed_datafile.file, format=CANONICAL_DATAFILE_FORMAT
+            )
+            data = reader.topography(info=measurement.instrument_info)
+            _log.info(
+                "Using canonical datafile instead of original datafile for "
+                f"measurement id {measurement.id}."
+            )
+
+        if data is None:
+            # `exists` finishes a pending upload, so it has to be called even when
+            # the answer is discarded.
+            if not measurement.datafile.exists():
+                raise RuntimeError(
+                    f"Measurement {measurement.id} does not appear to have a data "
+                    "file."
+                )
+            reader = get_topography_reader(
+                measurement.datafile.file, format=measurement.datafile_format
+            )
+            data = self.read_from_reader(
+                measurement, reader, apply_filters=apply_filters
+            )
+
+        return (data, reader) if return_reader else data
+
+    def read_from_reader(self, measurement, reader, apply_filters: bool = True):
+        """
+        Read the data object from an already opened reader.
+
+        Metadata stored on the measurement fills in whatever the file itself does
+        not provide; the file wins wherever it does, so that a reader gaining the
+        ability to report a value takes effect on the next read.
+        """
+        self._warn_if_expensive(measurement)
+
+        reader_kwargs = dict(
+            channel_index=measurement.data_source, periodic=measurement.is_periodic
+        )
+        channel = reader.channels[
+            reader.default_channel.index
+            if measurement.data_source is None
+            else measurement.data_source
+        ]
+
+        if channel.physical_sizes is None:
+            reader_kwargs["physical_sizes"] = self.physical_sizes_of(measurement)
+        if channel.height_scale_factor is None and measurement.height_scale:
+            reader_kwargs["height_scale_factor"] = measurement.height_scale
+        if channel.unit is None:
+            reader_kwargs["unit"] = measurement.unit
+        reader_kwargs["info"] = measurement.instrument_info
+
+        data = reader.topography(**reader_kwargs)
+        if apply_filters:
+            data = self.apply_filters(measurement, data)
+        return data
+
+    def apply_filters(self, measurement, data):
+        """Fill undefined data and detrend, according to the stored parameters."""
+        from ..manager.models import Measurement
+
+        if (
+            measurement.fill_undefined_data_mode
+            != Measurement.FILL_UNDEFINED_DATA_MODE_NOFILLING
+            and data.is_uniform
+        ):
+            data = data.interpolate_undefined_data(
+                measurement.fill_undefined_data_mode
+            )
+        return data.detrend(detrend_mode=measurement.detrend_mode)
+
+    @staticmethod
+    def physical_sizes_of(measurement):
+        """Physical sizes to pass to the reader when the file omits them."""
+        raise NotImplementedError
+
+    def _warn_if_expensive(self, measurement):
+        from ..taskapp.utils import in_celery_worker_process
+
+        if self.is_expensive_to_read and not in_celery_worker_process():
+            _log.warning(
+                f"You are requesting to load a ({self.dim}D) topography and you are "
+                "not within in a Celery worker process. This operation is "
+                "potentially slow and may require a lot of memory - do not use "
+                "`Measurement.read` within the main Django server!"
+            )
+
+    #
+    # Canonical file
+    #
+
+    def write_canonical_file(self, measurement, data, path):
+        data.to_netcdf(path)
+
+
+class LineScanType(SurfaceTopographyType):
+    """Common base of the one-dimensional height measurements."""
+
+    dim = 1
+
+    @staticmethod
+    def physical_sizes_of(measurement):
+        return (measurement.size_x,)
+
+    def render_thumbnail(self, measurement, data, width=400, height=400, cmap=None):
+        from matplotlib.figure import Figure
+
+        image_file = io.BytesIO()
+        dpi = 100
+        # Use the object-oriented API rather than `pyplot`. `pyplot` resolves the
+        # interactive backend, which on macOS is `macosx`; instantiating its canvas
+        # inside a forked Celery worker initializes AppKit on the child side of a
+        # fork, which the ObjC runtime aborts with SIGABRT. A bare `Figure` renders
+        # through Agg and keeps no global state, so it also removes the need to
+        # close the figure (see issue 898).
+        fig = Figure(figsize=[width / dpi, height / dpi])
+        ax = fig.subplots()
+        x, y = data.positions_and_heights()
+        ax.plot(x, y, "-")
+        ax.set_axis_off()
+        fig.savefig(
+            image_file,
+            bbox_inches="tight",
+            dpi=dpi,
+            format=settings.TOPOBANK_THUMBNAIL_FORMAT,
+        )
+        return image_file
+
+
+@register_measurement_type
+class TopographyMapType(SurfaceTopographyType):
+    """A two-dimensional map of heights."""
+
+    class Meta:
+        name = "topography-map"
+        display_name = "Topography map"
+
+    dim = 2
+    has_deepzoom = True
+    # Reading a map means pulling a full 2D array into memory.
+    is_expensive_to_read = True
+
+    @staticmethod
+    def physical_sizes_of(measurement):
+        return measurement.size_x, measurement.size_y
+
+    def render_thumbnail(self, measurement, data, width=400, height=400, cmap=None):
+        image_file = io.BytesIO()
+
+        # Compute thumbnail size, keeping the aspect ratio
+        sx, sy = data.physical_sizes
+        width2 = int(sx * height / sy)
+        height2 = int(sy * width / sx)
+        if width2 <= width:
+            width = width2
+        else:
+            height = height2
+
+        # Get heights and rescale to the interval [0, 1]
+        heights = data.heights()
+        mx, mn = heights.max(), heights.min()
+        heights = (heights - mn) / (mx - mn)
+        # `matplotlib.colormaps` is the pyplot-free lookup; `None` selects the
+        # default, as `pyplot.get_cmap` did.
+        if cmap is None:
+            cmap = matplotlib.colormaps[matplotlib.rcParams["image.cmap"]]
+        elif isinstance(cmap, str):
+            cmap = matplotlib.colormaps[cmap]
+        colors = (cmap(heights.T) * 255).astype(np.uint8)
+        # Drop the alpha channel before writing
+        PIL.Image.fromarray(colors[:, :, :3]).resize((width, height)).save(
+            image_file, format=settings.TOPOBANK_THUMBNAIL_FORMAT
+        )
+        return image_file
+
+    def make_deepzoom(self, measurement, data, manifest_set):
+        from ..manager.utils import render_deepzoom
+
+        render_deepzoom(data, manifest_set)
+
+
+@register_measurement_type
+class UniformLineScanType(LineScanType):
+    """A line scan on an evenly spaced grid."""
+
+    class Meta:
+        name = "uniform-line-scan"
+        display_name = "Uniform line scan"
+
+    is_uniform = True
+
+
+@register_measurement_type
+class NonuniformLineScanType(LineScanType):
+    """A line scan whose sample positions are arbitrary."""
+
+    class Meta:
+        name = "nonuniform-line-scan"
+        display_name = "Nonuniform line scan"
+
+    is_uniform = False
+
+
+#
+# Helpers shared by the model
+#
+
+
+def write_canonical_manifest(measurement, data):
+    """
+    Write `data` to a new canonical-file manifest and return it.
+
+    Kept here next to the format it writes; the model decides when to call it and
+    what to do with the old manifest.
+    """
+    from ..files.models import Manifest
+
+    measurement_type = measurement.measurement_type
+    with tempfile.NamedTemporaryFile(suffix=f".{CANONICAL_DATAFILE_FORMAT}") as tmp:
+        measurement_type.write_canonical_file(measurement, data, tmp.name)
+        _, basename = os.path.split(measurement.datafile.filename)
+        stem, _ = os.path.splitext(basename)
+        return Manifest.objects.create(
+            permissions=measurement.permissions,
+            filename=f"{stem}-squeezed.{CANONICAL_DATAFILE_FORMAT}",
+            kind="der",
+            file=File(open(tmp.name, mode="rb")),
+        )
+
+
+def write_thumbnail_manifest(measurement, image_file):
+    """Write a rendered thumbnail to a new manifest and return it."""
+    from ..files.models import Manifest
+
+    manifest = Manifest.objects.create(
+        permissions=measurement.permissions,
+        filename=f"thumbnail.{settings.TOPOBANK_THUMBNAIL_FORMAT}",
+        kind="der",
+    )
+    manifest.save_file(ContentFile(image_file.getvalue()))
+    return manifest

--- a/topobank/test_settings.py
+++ b/topobank/test_settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
     "topobank.testing.mock_auth.apps.AuthorizationAppConfig",
     "topobank.files.apps.FilesAppConfig",
     "topobank.manager.apps.ManagerAppConfig",
+    "topobank.measurements.apps.MeasurementsAppConfig",
     "topobank.analysis.apps.AnalysisAppConfig",
     "topobank.testing.mock_auth.apps.OrganizationsAppConfig",
     "topobank.properties.apps.PropertiesAppConfig",


### PR DESCRIPTION
PR 2 of the series splitting #1366, on top of #1386. Targets `26_measurement_model`.

Adds `Measurement.kind` and a registry of measurement **handlers**. **Metadata deliberately stays in the typed columns** — moving it into validated JSON is PR 3. This PR moves only *behaviour*, so it can be reviewed without also reviewing a schema layer and a data migration.

## The shape

A handler owns everything that depends on what kind of data is being handled: which channels it can import, how the file is read, which derived artifacts exist. The model stops deciding that by testing field values.

```
Measurement.kind ──> registry ──> MeasurementHandler
                                    ├── claims_channel()   which kind a channel is imported as
                                    ├── read()             reader kwargs + filters
                                    ├── render_thumbnail()
                                    ├── make_deepzoom()
                                    └── capabilities: has_deepzoom, has_canonical_file,
                                                      yields_surface_topography, ...
```

`kind` is the stored discriminator, the handler is the resolved implementation, and `Meta.kind` on the handler is the same string as the column — spelled that way so the link is visible at every site:

```python
measurement.kind                 # "topography-map"  — stored, stable, in containers
measurement.handler              # TopographyMapHandler singleton
measurement.handler.Meta.kind    # "topography-map"
measurement.handler.has_deepzoom
```

Three built-in handlers cover height data (`topography-map`, `uniform-line-scan`, `nonuniform-line-scan`) and share `SurfaceTopographyHandler`, which holds everything going through `SurfaceTopography.IO`. A handler for another modality subclasses `MeasurementHandler` directly and brings its own data package.

## What moved out of the model

- **`read`** dispatches to the handler. The canonical-file shortcut, the reader kwargs and the filters live there now.
- **The thumbnail** is rendered by the handler, so the `dim == 1` / `dim == 2` branch is gone — each handler renders its own. The *storage* plumbing (which manifest to replace, which permissions to use) stays on the model, where it is identical for every kind. That split is the main judgement call in this PR and the thing most worth disagreeing with.
- **Deep Zoom and the canonical file** follow the `has_deepzoom` / `has_canonical_file` capabilities instead of `size_y is not None`, including in the completeness check at the end of `refresh_cache`.

`models.py` loses its `io`, `os.path`, `tempfile`, `matplotlib`, `PIL`, `ContentFile` and `Figure` imports as a result, which is a decent sign the move is real rather than cosmetic.

## Kind assignment, and why it is one-way

The kind is derived from the selected channel while the file is inspected. An existing kind is **never** overwritten:

```python
if self.kind is None:
    self.kind = infer_kind(channel)
```

A reader that changes its mind about a channel between releases must not silently turn stored data into a different kind of measurement. The test asserts `infer_kind` is *not called* rather than that the stored value is unchanged — a rule that merely happened to re-infer the same value would pass the weaker check while still being wrong.

A measurement with **no** recorded kind still works: `handler` derives one from the data file on demand. Importing a container builds measurements straight from the archive's metadata without ever inspecting a file, so nothing records a kind, and those measurements have to stay readable. Deriving does not write the column — inspection remains the only writer. `has_handler` deliberately does not fall back, so listing many measurements does not become one file open each.

## Migrations

**`0085`** adds the column. **`0086`** backfills it from what inspection already wrote, rather than reopening every stored data file:

- `resolution_y` is set only for two-dimensional data → topography map.
- `is_periodic_editable` is cleared only for non-uniform data (periodicity is meaningless there) → separates the two kinds of line scan.
- `resolution_x` is written on every inspection, so a null there means the file was never inspected. Those rows keep a null kind and get one when first inspected.

Three queryset updates, not row by row — this runs over every measurement in the database. Rows that already have a kind are left alone, so a plugin's measurements are not relabelled by column rules that know nothing about them.

## Graceful degradation

A measurement whose kind has no registered handler — the plugin that created it is gone — stays listable, renameable and deletable. Only reading its data raises, with a message naming the missing kind. That is tested, since it is the whole point of storing a key rather than a class reference.

## Naming

The handler was called `MeasurementType` and reached through `measurement.measurement_type` in the first two commits. Renamed after review feedback that the code was hard to read: the property stuttered, and the object was a "type" while the string identifying it was a "kind" — two words for one concept. `Meta.name` was the worst of it, since it held the kind, sat beside a `display_name` that was the actual name, and gave no hint of being the same string as the column.

Not `parser`, which was the other candidate: `SurfaceTopography`'s `ReaderBase` is what parses bytes here, a handler holds one, and most of what a handler does is not parsing.

The entry-point group changed with it, `topobank.measurement_types` → `topobank.measurement_handlers`. That string is the one name here that becomes public API once released, so this was the last free moment; nothing declares it yet.

## Verification

- `flake8` clean, `makemigrations --check --dry-run` clean
- **393 passed, 4 skipped** — 363 before, so 30 new tests; unchanged across the rename, which is the point of doing it as a separate commit

Checked against mutants rather than only for passing — each of these fails a test:

| Mutation | Fails |
| --- | --- |
| Backfill collapses the uniform/non-uniform split | `test_the_backfill_reconstructs_the_kind_from_the_columns[…nonuniform…]` |
| Backfill overwrites an existing kind | `test_the_backfill_leaves_an_existing_kind_alone` |
| Model drops the overwrite guard | `test_reinspection_does_not_reinterpret_an_existing_measurement` |
| `handler` requires a recorded kind | 3 tests, including the container round trip |

The last row is a regression CI caught after the first push: requiring a recorded kind broke container import. The local suite had missed it because the container tests need a live remote and **skip** in my environment — so the fix ships with an `export_container_zip` → `import_container_zip` round trip that needs no network.

## Known rough edge

Which fields are meaningful for which kind is still implicit — `size_y` being null is what makes a record a line scan, and `LineScanHandler.physical_sizes_of` knows to return a 1-tuple. That is exactly what PR 3 fixes by giving each kind a schema; flagging it here so it reads as deferred rather than missed.

Next: pydantic metadata schemas, the `metadata`/`file_info` JSON fields, backfill and column drop.